### PR TITLE
Blend SoC sent to MCM by 0.1% increments

### DIFF
--- a/Firmware/MVP/BringupTester.cpp
+++ b/Firmware/MVP/BringupTester.cpp
@@ -50,9 +50,9 @@ void bringupTester_run(void)
 				Serial.print(F("\nLTC6804 - isoSPI error count is "));
 				Serial.print(String(LTC68042result_errorCount_get()));
 				Serial.print(F(": "));
-			
+
 				if( LTC68042result_errorCount_get() == 0 ) { Serial.print(F("pass")); }
-				else { Serial.print(F("FAIL!!!!!!!!!!!!!")); didTestFail = true; } //at least one isoSPI error occurred
+				else { Serial.print(F("FAIL!! !! !! !! !")); didTestFail = true; } //at least one isoSPI error occurred
 
 				//display all cell voltages
 				for(uint8_t ii=0; ii<TOTAL_IC; ii++) { debugUSB_printOneICsCellVoltages( ii, 3); }
@@ -60,8 +60,8 @@ void bringupTester_run(void)
 				Serial.print(F("\nmax cell: "));
 				Serial.print(String(LTC68042result_hiCellVoltage_get()));
 				Serial.print(F("\nmin cell: "));
-				Serial.print(String(LTC68042result_loCellVoltage_get()));	
-		
+				Serial.print(String(LTC68042result_loCellVoltage_get()));
+
 				Serial.print(F("\n\nLTC6804 - verify no shorts: "));
 				serialUSB_waitForEmptyBuffer();
 				//verify all cells are in range
@@ -74,7 +74,7 @@ void bringupTester_run(void)
 					else                                             { testToRun = TEST_TYPE_GAUNTLET;       } //LED BMS board connected
 
 				} else {
-					Serial.print(F("FAIL!!!!!!!!!!!!!!!! (check BMS leads & supply)"));
+					Serial.print(F("FAIL!! !! !! !! !! ! (check BMS leads & supply)"));
 					didTestFail = true;
 				}
 			}
@@ -82,7 +82,7 @@ void bringupTester_run(void)
 			//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 			if(testToRun == TEST_TYPE_GAUNTLET)
-			{	
+			{
 				/////////////////////////////////////////////////////////////////////
 
 				//test LEDs/display
@@ -99,7 +99,7 @@ void bringupTester_run(void)
 
 				//Turn 4x20 screen on
 				Serial.print(F("\nWriting Data to 4x20 LCD"));
-				serialUSB_waitForEmptyBuffer();		
+				serialUSB_waitForEmptyBuffer();
 				lcd_initialize();
 				lcd_printStaticText();
 				lcd_displayON();
@@ -147,7 +147,7 @@ void bringupTester_run(void)
 					uint8_t numberLoopedBack = 0;
 					while ( LiDisplay_bytesAvailableToRead() != 0 ) { numberLoopedBack = LiDisplay_readByte(); }
 					if(numberLoopedBack == numberToLoopback) { Serial.print(F("pass")); }
-					else                                     { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!!!")); didTestFail = true; }
+					else                                     { Serial.print(F("FAIL!! !! !! !! !! !! !! !! ")); didTestFail = true; }
 				}
 
 				/////////////////////////////////////////////////////////////////////
@@ -173,7 +173,7 @@ void bringupTester_run(void)
 					uint8_t numberLoopedBack = 0;
 					while ( METSCI_bytesAvailableToRead() != 0 ) { numberLoopedBack = METSCI_readByte(); }
 					if(numberLoopedBack == numberToLoopback) { Serial.print(F("pass")); }
-					else                                     { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!!!")); didTestFail = true; }
+					else                                     { Serial.print(F("FAIL!! !! !! !! !! !! !! !! ")); didTestFail = true; }
 
 			    	BATTSCI_disable();
 			   		METSCI_disable();
@@ -198,7 +198,7 @@ void bringupTester_run(void)
 					Serial.print( String(tempBLU) + ": ");
 
 					if((tempYEL > 950) && (tempGRN > 950) && (tempWHT > 950) && (tempBLU > 950)) { Serial.print(F("pass")); }
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")); didTestFail=true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !! !! !! !! !!")); didTestFail=true; }
 				}
 
 				//lithium module sensors
@@ -212,7 +212,7 @@ void bringupTester_run(void)
 					Serial.print( String(tempBAY3) + ": ");
 
 					if((tempBAY1 > 950) && (tempBAY2 > 950) && (tempBAY3 > 950)) { Serial.print(F("pass")); }
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")); didTestFail=true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !! !! !! !! !!")); didTestFail=true; }
 				}
 
 				/////////////////////////////////////////////////////////////////////
@@ -223,7 +223,7 @@ void bringupTester_run(void)
 
 				gpio_turnTemperatureSensors_on();
 				delay(500); //wait for temp sensor LPF
-				
+
 				//OEM sensors
 				{
 					uint16_t tempYEL = adc_getTemperature(PIN_TEMP_YEL);
@@ -240,7 +240,7 @@ void bringupTester_run(void)
 					   (tempGRN > 462) && (tempGRN < 562) &&
 					   (tempWHT > 462) && (tempWHT < 562) &&
 					   (tempBLU > 462) && (tempBLU < 562)) { Serial.print(F("pass")); }
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")); didTestFail=true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !! !! !! !! !!")); didTestFail=true; }
 				}
 
 				//lithium module sensors
@@ -256,7 +256,7 @@ void bringupTester_run(void)
 					if((tempBAY1 > 462) && (tempBAY1 < 562) &&
 					   (tempBAY2 > 462) && (tempBAY2 < 562) &&
 					   (tempBAY3 > 462) && (tempBAY3 < 562)) { Serial.print(F("pass")); }
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")); didTestFail=true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !! !! !! !! !!")); didTestFail=true; }
 				}
 
 				gpio_turnTemperatureSensors_off();
@@ -266,7 +266,7 @@ void bringupTester_run(void)
 				//test current sensor, both OEM fan speeds, and onboard fans
 				//Lambda Gen is set to 2V@3A, and is open-drained thru QTY3 fan drive FETs (in parallel, tested one at a time)
 				//current sensor has QTY19 turns, so 3A is seen as 57 amps assist.
-	
+
 				Serial.print(F("\n\nCurrent sensor 10b result @ 0A is "));
 				serialUSB_waitForEmptyBuffer();
 				{
@@ -278,7 +278,7 @@ void bringupTester_run(void)
 					Serial.print(String(resultADC));
 					Serial.print(F(" counts: "));
 					if((resultADC > 328) && (resultADC < 336)) { Serial.print(F("pass")); }
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")); didTestFail=true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !! !! !! !! !!")); didTestFail=true; }
 				}
 
 				Serial.print(F("\nCurrent sensor 10b result @ 3A through OEM_FAN_L is "));
@@ -292,7 +292,7 @@ void bringupTester_run(void)
 					Serial.print(String(resultADC));
 					Serial.print(F(" counts: "));
 					if((resultADC > 585) && (resultADC < 605)) { Serial.print(F("pass")); }
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")); didTestFail=true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !! !! !! !! !!")); didTestFail=true; }
 				}
 
 				Serial.print(F("\nCurrent sensor 10b result @ 3A through OEM_FAN_H is "));
@@ -306,7 +306,7 @@ void bringupTester_run(void)
 					Serial.print(String(resultADC));
 					Serial.print(F(" counts: "));
 					if((resultADC > 585) && (resultADC < 605)) { Serial.print(F("pass")); }
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")); didTestFail=true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !! !! !! !! !!")); didTestFail=true; }
 				}
 
 				Serial.print(F("\nCurrent sensor 10b result @ 3A through onboard fans is "));
@@ -320,7 +320,7 @@ void bringupTester_run(void)
 					Serial.print(String(resultADC));
 					Serial.print(F(" counts: "));
 					if((resultADC > 585) && (resultADC < 605)) { Serial.print(F("pass")); }
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")); didTestFail=true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !! !! !! !! !!")); didTestFail=true; }
 				}
 
 				//test that OEM current sensor turns off correctly
@@ -335,7 +335,7 @@ void bringupTester_run(void)
 
 					uint16_t resultADC = analogRead(PIN_BATTCURRENT); // 0A is 330 counts
 					if((resultADC > 328) && (resultADC < 336)) { Serial.print(F("pass")); }
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")); didTestFail=true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !! !! !! !! !!")); didTestFail=true; }
 				}
 
 				//turn all FETs off (so they don't overheat)
@@ -353,7 +353,7 @@ void bringupTester_run(void)
 					uint16_t result = analogRead(PIN_VPIN_IN);
 					Serial.print(String(result));
 					if(result < 40) { Serial.print(F(" pass")); } //40 counts is 0.2 volts
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!")); didTestFail = true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !! !! !")); didTestFail = true; }
 
 					analogWrite(PIN_VPIN_OUT_PWM,127); // 127 counts = 2.5 volts
 					delay(200); //LPF
@@ -361,7 +361,7 @@ void bringupTester_run(void)
 					Serial.print(F("\nVPIN Loopback @ 2.5V: "));
 					Serial.print(String(result));
 					if((result < 532) && (result > 492)) { Serial.print(F(" pass")); } //492 counts is 2.4 volts //532 counts is 2.6 volts
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!")); didTestFail = true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !! !! !")); didTestFail = true; }
 
 					analogWrite(PIN_VPIN_OUT_PWM,255); // 255 counts = 5.0 volts
 					delay(200); //LPF
@@ -369,7 +369,7 @@ void bringupTester_run(void)
 					Serial.print(F("\nVPIN Loopback @ 5.0V: "));
 					Serial.print(String(result));
 					if(result > 984) { Serial.print(F(" pass")); } //984 counts is 4.8 volts
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!!!!!!!")); didTestFail = true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !! !! !")); didTestFail = true; }
 
 				}
 
@@ -382,7 +382,7 @@ void bringupTester_run(void)
 					gpio_turnGridCharger_off(); //turn IGBT off (power applied to grid charger side)
 					delay(25);
 					if( gpio_isGridChargerPluggedInNow() == false ) { Serial.print(F("pass")); }
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!")); didTestFail = true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !")); didTestFail = true; }
 				}
 
 				Serial.print(F("\nTesting if grid IGBT is on:  "));
@@ -391,7 +391,7 @@ void bringupTester_run(void)
 					gpio_turnGridCharger_on(); //turn IGBT on... grid sense should now see power
 					delay(25);
 					if( gpio_isGridChargerPluggedInNow() == true ) { Serial.print(F("pass")); }
-					else { Serial.print(F("FAIL!!!!!!!!!!!!!!!!")); didTestFail = true; }
+					else { Serial.print(F("FAIL!! !! !! !! !! !")); didTestFail = true; }
 				}
 
 				gpio_turnGridCharger_off();
@@ -407,7 +407,7 @@ void bringupTester_run(void)
 					gpio_setGridCharger_powerLevel('H'); //open drain is left floating (negative logic)
 					delay(100);
 					if( gpio_keyStateNow() == true ) { Serial.print(F("pass")); } //key appears on
-					else { Serial.print(F("FAIL!!!!!!!!!!")); didTestFail = true; }
+					else { Serial.print(F("FAIL!! !! !! !")); didTestFail = true; }
 				}
 
 				Serial.print(F("\nTesting GRID_PWM: "));
@@ -416,14 +416,14 @@ void bringupTester_run(void)
 					gpio_setGridCharger_powerLevel('0'); //open drain is shorted (negative logic)
 					delay(100);
 					if( gpio_keyStateNow() == false ) { Serial.print(F("pass")); } //GRID_PWM's open collector is pulling to 0V
-					else { Serial.print(F("FAIL!!!!!!!!!!")); didTestFail = true; }
+					else { Serial.print(F("FAIL!! !! !! !")); didTestFail = true; }
 				}
 				//Don't add any code here
 				Serial.print(F("\nTesting 12V_KEYON state is OFF: "));
 				serialUSB_waitForEmptyBuffer();
 				{
 					if( gpio_keyStateNow() == false ) { Serial.print(F("pass")); } //key appears off
-					else { Serial.print(F("FAIL!!!!!!!!!!")); didTestFail = true; }
+					else { Serial.print(F("FAIL!! !! !! !")); didTestFail = true; }
 				}
 
 				gpio_setGridCharger_powerLevel('H'); //turn GRID_PWM off (negative logic)
@@ -434,7 +434,7 @@ void bringupTester_run(void)
 				gpio_turnBuzzer_on_highFreq();
 
 				if( didTestFail == false) { Serial.print(F("\n\nUnit PASSED!\n\n")); delay(100); }
-				else {	          Serial.print(F("\n\nUnit FAILED!!!!!!!!!!!\n\n")); delay(999); }
+				else {	          Serial.print(F("\n\nUnit FAILED!! !! !! !!\n\n")); delay(999); }
 				gpio_turnBuzzer_off();
 
 			}
@@ -448,7 +448,7 @@ void bringupTester_run(void)
 				//JTS note: The LTC6804 cannot enable discharge resistors with high impedance spoofed BMS voltage (i.e. from series LED chain).
 				//This is due to -2.5V PFET gate threshold voltage & also LTC6804 "Discharge Switch On-Resistance vs Cell Voltage" (p14).
 				//Therefore, to test discharge resistors, run test again with actual batteries plugged in, then use thermal imager.
-				
+
 				//JTS2doLater: Solder together a 75 Ohm test board - similar to existing LED test board - so that the above is no longer an issue.
 
 				LTC68042configure_wakeupCore();

--- a/Firmware/MVP/battsci.cpp
+++ b/Firmware/MVP/battsci.cpp
@@ -14,6 +14,28 @@
 uint8_t spoofedVoltageToSend_Counts = 0; //formatted as MCM expects to see it (Vpack / 2) //2 volts per count
 int16_t spoofedCurrentToSend_Counts = 0; //formatted as MCM expects to see it (2048 - amps * 20) //50 mA per count
 
+//LUT remaps actual lithium battery SoC (unit: percent) to mimic OEM NiMH behavior (unit: deciPercent)
+//input: actual lithium SoC (unit: percent integer)
+//output: OEM NiMH SoC equivalent (unit: decipercent integer)
+//Example: if the actual lithium SoC is 85%, then "remap_actualToSpoofedSoC[85]" will return 799d (79.9%), which is the value to send on BATTSCI
+const uint16_t remap_actualToSpoofedSoC[101] = {
+	  0, 22, 44, 67, 89,111,133,156,178,190, //LiCBM SoC = 00% to 09%
+	200,209,217,225,232,240,248,256,264,272, //LiCBM SoC = 10% to 19%
+	279,287,295,303,311,319,326,334,342,350, //LiCBM SoC = 20% to 29% //MCM enables heavy regen below 350 (35.0%)
+	355,363,375,387,399,411,423,435,447,459, //LiCBM SoC = 30% to 39% //MCM enables light regen below 700 (70.0%)
+	471,483,495,507,519,532,544,556,568,580, //LiCBM SoC = 40% to 49%
+	592,604,616,628,640,652,664,676,688,700, //LiCBM SoC = 50% to 59% //MCM disables background regen agove 582 (58.2%)
+	701,705,709,713,717,721,725,728,732,736, //LiCBM SoC = 60% to 69% //TODO_NATALYA (not urgent as of 2022JAN21) evaluate regen behaviour while driving to see if LiBCM 60 to 69 needs to be remapped to a smaller MCM range of 69 to 72, or if this range needs to begin at LiBCM 60 = MCM 68% instead of 70%
+	740,744,748,752,756,760,764,768,772,775, //LiCBM SoC = 70% to 79%
+	779,783,787,791,795,799,800,814,829,843, //LiCBM SoC = 80% to 89% //MCM disables regen above 800 (80.0%)
+	857,871,886,900,914,929,943,957,971,986, //LiCBM SoC = 90% to 99%
+	1000,                                    //LiCBM SoC = 100%
+};  //Data empirically gathered from OEM NiMH IMA system //see ../Firmware/Prototype Building Blocks/Remap SoC.ods for calculations
+
+uint16_t previousOutputSoC = remap_actualToSpoofedSoC[SoC_getBatteryStateNow_percent()];
+//uint16_t previousOutputSoC = 700;
+
+
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void BATTSCI_begin(void)
@@ -23,6 +45,9 @@ void BATTSCI_begin(void)
 
   pinMode(PIN_BATTSCI_REn, OUTPUT);
   digitalWrite(PIN_BATTSCI_REn,HIGH);
+
+//previousOutputSoC = 400;
+  previousOutputSoC = remap_actualToSpoofedSoC[SoC_getBatteryStateNow_percent()]; // If user grid charged over night SoC may have changed a lot.
 
   Serial2.begin(9600,SERIAL_8E1);
   Serial.print(F("\nBATTSCI BEGIN"));
@@ -47,7 +72,7 @@ uint8_t BATTSCI_writeByte(uint8_t data) { Serial2.write(data); return data; }
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 //Convert battery voltage (unit: volts) into BATTSCI format (unit: 2 volts per count)
-void BATTSCI_setPackVoltage(uint8_t spoofedVoltage) { spoofedVoltageToSend_Counts = (spoofedVoltage >> 1); } 
+void BATTSCI_setPackVoltage(uint8_t spoofedVoltage) { spoofedVoltageToSend_Counts = (spoofedVoltage >> 1); }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -90,7 +115,7 @@ int16_t cellVoltageOffsetDueToESR(void)
   //Derivation:
   //  vCellCorrection_ESR = Icell_amps                * ESR
   //  vCellCorrection_ESR = Icell_amps                *  2 mOhm
-  //  vCellCorrection_ESR = Icell_amps                * 20 counts 
+  //  vCellCorrection_ESR = Icell_amps                * 20 counts
   return (int16_t)(adc_getLatestBatteryCurrent_amps() * CELL_ESR_COUNTS);
 }
 
@@ -98,14 +123,14 @@ int16_t cellVoltageOffsetDueToESR(void)
 
 bool BATTSCI_isPackFull(void)
 {
-  // uint16_t currentAdjustedCellVoltage_max = CELL_VMAX_REGEN; 
+  // uint16_t currentAdjustedCellVoltage_max = CELL_VMAX_REGEN;
   // JTS2doNow: Determine regen cell ESR
   // if(adc_getLatestBatteryCurrent_amps() < 0)
-  // { 
+  // {
   //   //regen, need to account for ESR-related cell voltage increase
   //   currentAdjustedCellVoltage_max = CELL_VREST_85_PERCENT_SoC - cellVoltageOffsetDueToESR(); //fcn returns negative number (- - = +)
   // }
-    
+
   if( (LTC68042result_hiCellVoltage_get() < CELL_VMAX_REGEN               ) && //below hard voltage limit (if SoC estimator is wrong)
       //(LTC68042result_hiCellVoltage_get() < currentAdjustedCellVoltage_max) && //below ESR-adjusted voltage limit (due to IMA current) //JTS2doNow: required?
       (  SoC_getBatteryStateNow_percent() < STACK_SoC_MAX                 ) )  //below SoC limit
@@ -122,7 +147,7 @@ bool BATTSCI_isPackEmpty(void)
   //account for additional cell voltage drop during assist
   if(adc_getLatestBatteryCurrent_amps() > 0) { currentAdjusted_Vmin = CELL_VMIN_ASSIST - cellVoltageOffsetDueToESR(); }
 
-  if( (LTC68042result_loCellVoltage_get() > CELL_VMIN_ASSIST              ) && //above hard voltage limit (if SoC estimator is wrong) 
+  if( (LTC68042result_loCellVoltage_get() > CELL_VMIN_ASSIST              ) && //above hard voltage limit (if SoC estimator is wrong)
       (LTC68042result_loCellVoltage_get() > currentAdjusted_Vmin) && //above ESR-adjusted voltage limit (due to IMA current)
       (  SoC_getBatteryStateNow_percent() > STACK_SoC_MIN                 ) )  //above SoC limit
        { return false; } //pack is good
@@ -172,10 +197,11 @@ uint8_t BATTSCI_calculateChargeRequestByte(void)
 //Adjust final SoC value as needed to improve driving characteristics
 uint16_t BATTSCI_SoC_Hysteresis(uint16_t SoC_mappedToMCM_deciPercent)
 {
-  //TODO_NATALYA: Try to contain your SoC hysteresis variables and logic here.  If they need to be elsewhere, that's fine, but much cleaner to place here.
-  //examples:
-  //static uint16_t lastSoC_sentToMCM = 0;
-  //static uint16_t SoC_sentToMCMDelayIncrement...
+  if (SoC_mappedToMCM_deciPercent > previousOutputSoC) {
+	  SoC_mappedToMCM_deciPercent = previousOutputSoC + 1;
+  } else if (SoC_mappedToMCM_deciPercent < previousOutputSoC) {
+	  SoC_mappedToMCM_deciPercent = previousOutputSoC - 1;
+  }
 
   #ifdef REDUCE_BACKGROUND_REGEN_UNLESS_BRAKING
     if( (SoC_mappedToMCM_deciPercent < 720) && (SoC_mappedToMCM_deciPercent > 250) ) { SoC_mappedToMCM_deciPercent = 720; }
@@ -185,12 +211,15 @@ uint16_t BATTSCI_SoC_Hysteresis(uint16_t SoC_mappedToMCM_deciPercent)
 
   #endif
 
+  previousOutputSoC = SoC_mappedToMCM_deciPercent;
+
   return SoC_mappedToMCM_deciPercent;
+  //return previousOutputSoC;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-//Convert spoofed SoC value (unit: deciPercent) into BATTSCI data (two bytes)  
+//Convert spoofed SoC value (unit: deciPercent) into BATTSCI data (two bytes)
 uint16_t BATTSCI_convertSoC_deciPercent_toBytes(uint16_t SoC_deciPercent) //deciPercent = % * 10 //Example: 72.1% = 721 deciPercent
 {
   //Useful BATTSCI SoC values:
@@ -206,17 +235,17 @@ uint16_t BATTSCI_convertSoC_deciPercent_toBytes(uint16_t SoC_deciPercent) //deci
   //each count in the lower byte is 0.1%, with a range from 0 (0x00) to 127 (0x7F) (0.0 to 12.7% SoC).
   //each count in the upper byte's lower nibble represents 12.8% SoC.
   //              the upper byte's upper nibble has several unknown flags, and is either 0b0001 (usually) or 0b0010 (sometimes)
-  
+
   //Example: convert BATTSCI(two bytes) to SoC(%)
   //  given BATTSCI bytes:     0x15 0x50 = 21d 81d = 0b00010101 0b01010001
   //  mask out upper byte's upper nibble = 05d 80d = 0b00000101 0b01010001
   //  upperByte_SoC is 05d * 12.8% = 64.0%
-  //  lowerByte_SoC is 81d *  0.1% =  8.1% 
-  //  totalSoC = 64.0% + 8.1% = 72.1%  
+  //  lowerByte_SoC is 81d *  0.1% =  8.1%
+  //  totalSoC = 64.0% + 8.1% = 72.1%
 
   //Example: convert SoC(%) to BATTSCI(two bytes)
   //  given totalSoC: 72.1% = 721d
-  //  upperByteTemp = (721d / 128d) = 05d = 0b00000101 //each count in upper byte is 12.8% (128d) 
+  //  upperByteTemp = (721d / 128d) = 05d = 0b00000101 //each count in upper byte is 12.8% (128d)
   //  lowerByte = totalSoC - (upperByteTemp * 128d) = 721d - (05d * 128d) = 721d - 640d = 81d //subtract SoC portion represented by upper byte
   //  upperByte = (upperByteTemp | 0b00010000) = (0b00000101 | 0b00010000) = 0b00010101 = 21d //set upper nibble's unknown flag
 
@@ -232,27 +261,9 @@ uint16_t BATTSCI_convertSoC_deciPercent_toBytes(uint16_t SoC_deciPercent) //deci
 
 uint16_t BATTSCI_calculateSpoofedSoC(void)
 {
-  //LUT remaps actual lithium battery SoC (unit: percent) to mimic OEM NiMH behavior (unit: deciPercent)
-  //input: actual lithium SoC (unit: percent integer)
-  //output: OEM NiMH SoC equivalent (unit: decipercent integer)
-  //Example: if the actual lithium SoC is 85%, then "remap_actualToSpoofedSoC[85]" will return 799d (79.9%), which is the value to send on BATTSCI
-  static const uint16_t remap_actualToSpoofedSoC[101] = {  
-        0, 22, 44, 67, 89,111,133,156,178,190, //LiCBM SoC = 00% to 09% 
-      200,209,217,225,232,240,248,256,264,272, //LiCBM SoC = 10% to 19%
-      279,287,295,303,311,319,326,334,342,350, //LiCBM SoC = 20% to 29% //MCM enables heavy regen below 350 (35.0%)
-      355,363,375,387,399,411,423,435,447,459, //LiCBM SoC = 30% to 39% //MCM enables light regen below 700 (70.0%)
-      471,483,495,507,519,532,544,556,568,580, //LiCBM SoC = 40% to 49% 
-      592,604,616,628,640,652,664,676,688,700, //LiCBM SoC = 50% to 59% //MCM disables background regen agove 582 (58.2%)
-      701,705,709,713,717,721,725,728,732,736, //LiCBM SoC = 60% to 69%
-      740,744,748,752,756,760,764,768,772,775, //LiCBM SoC = 70% to 79%
-      779,783,787,791,795,799,800,814,829,843, //LiCBM SoC = 80% to 89% //MCM disables regen above 800 (80.0%)
-      857,871,886,900,914,929,943,957,971,986, //LiCBM SoC = 90% to 99%
-      1000,                                    //LiCBM SoC = 100%
-    };  //Data empirically gathered from OEM NiMH IMA system //see ../Firmware/Prototype Building Blocks/Remap SoC.ods for calculations
-  
   uint16_t SoC_toMCM_deciPercent = 0;
   if     (BATTSCI_isPackFull()  == true) { SoC_toMCM_deciPercent = 820; } //disable regen  //JTS2doNow: See if this is actually required (also sent as flag)
-  else if(BATTSCI_isPackEmpty() == true) { SoC_toMCM_deciPercent = 200; } //disable assist  
+  else if(BATTSCI_isPackEmpty() == true) { SoC_toMCM_deciPercent = 200; } //disable assist //TODO_NATALYA (not urgent as of 2022JAN21) watch SoC gauge behaviour at 20% MCM SoC vs 19% MCM SoC to see if we should use 20% or 19%
   else { SoC_toMCM_deciPercent = remap_actualToSpoofedSoC[SoC_getBatteryStateNow_percent()]; } //get MCM-remapped SoC value
 
   SoC_toMCM_deciPercent = BATTSCI_SoC_Hysteresis(SoC_toMCM_deciPercent);
@@ -263,7 +274,7 @@ uint16_t BATTSCI_calculateSpoofedSoC(void)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void BATTSCI_sendFrames(void)
-{ 
+{
   static uint32_t previousMillis = 0;
 
   if( ( BATTSCI_bytesAvailableForWrite() > BATTSCI_BYTES_IN_FRAME ) && //Verify serial send ring buffer has room
@@ -281,15 +292,15 @@ void BATTSCI_sendFrames(void)
       frameSum_87 += BATTSCI_writeByte( 0x87 );                                              //B0 Never changes
       frameSum_87 += BATTSCI_writeByte( 0x40 );                                              //B1 Never changes
       frameSum_87 += BATTSCI_writeByte( spoofedVoltageToSend_Counts );                       //B2 Half Vbatt_actual (e.g. 0x40 = d64 = 128 V
-    
+
       uint16_t spoofedSoC_Bytes = BATTSCI_calculateSpoofedSoC();
       frameSum_87 += BATTSCI_writeByte( highByte(spoofedSoC_Bytes) );                        //B3 SoC (upper byte)
       frameSum_87 += BATTSCI_writeByte(  lowByte(spoofedSoC_Bytes) );                        //B4 SoC (lower byte)
-    
+
       frameSum_87 += BATTSCI_writeByte( highByte(spoofedCurrentToSend_Counts << 1) & 0x7F ); //B5 Battery Current (upper byte)
       frameSum_87 += BATTSCI_writeByte(  lowByte(spoofedCurrentToSend_Counts     ) & 0x7F ); //B6 Battery Current (lower byte)
       frameSum_87 += BATTSCI_writeByte( 0x32 );                                              //B7 always 0x32, except before 0xAAbyte5 changes from 0x00 to 0x10 (then 0x23)
-      frameSum_87 += BATTSCI_writeByte( BATTSCI_calculateTemperatureByte() );                //B8 max battery module temp
+      frameSum_87 += BATTSCI_writeByte( BATTSCI_calculateTemperatureByte() );                //B8 max battery module temp //TODO_JTS: Could we store the result of BATTSCI_calculateTemperatureByte so the function doesn't need to be performed twice per frame?
       frameSum_87 += BATTSCI_writeByte( BATTSCI_calculateTemperatureByte() );                //B9 min battery module temp
       frameSum_87 += BATTSCI_writeByte( METSCI_getPacketB3() );                              //B10 MCM latest B3 data byte
                      BATTSCI_writeByte( BATTSCI_calculateChecksum(frameSum_87) );            //B11 Send Checksum. sum(byte0:byte11) should equal 0

--- a/Firmware/MVP/battsci.cpp
+++ b/Firmware/MVP/battsci.cpp
@@ -33,7 +33,6 @@ const uint16_t remap_actualToSpoofedSoC[101] = {
 };  //Data empirically gathered from OEM NiMH IMA system //see ../Firmware/Prototype Building Blocks/Remap SoC.ods for calculations
 
 uint16_t previousOutputSoC = remap_actualToSpoofedSoC[SoC_getBatteryStateNow_percent()];
-//uint16_t previousOutputSoC = 700;
 
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -46,7 +45,6 @@ void BATTSCI_begin(void)
   pinMode(PIN_BATTSCI_REn, OUTPUT);
   digitalWrite(PIN_BATTSCI_REn,HIGH);
 
-//previousOutputSoC = 400;
   previousOutputSoC = remap_actualToSpoofedSoC[SoC_getBatteryStateNow_percent()]; // If user grid charged over night SoC may have changed a lot.
 
   Serial2.begin(9600,SERIAL_8E1);
@@ -214,7 +212,6 @@ uint16_t BATTSCI_SoC_Hysteresis(uint16_t SoC_mappedToMCM_deciPercent)
   previousOutputSoC = SoC_mappedToMCM_deciPercent;
 
   return SoC_mappedToMCM_deciPercent;
-  //return previousOutputSoC;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Firmware/MVP/config.h
+++ b/Firmware/MVP/config.h
@@ -8,17 +8,18 @@
 	#include "libcm.h"  //For Arduino IDE compatibility
 
 	#define FW_VERSION "0.6.3"
-    #define BUILD_DATE "2022JAN21"
+    #define BUILD_DATE "2022JAN24"
 
 	#define CPU_MAP_MEGA2560
 
     //chose ONE of the following:
+    	//#define HW_REVB
     	#define HW_REVC
 
 	//choose ONE of the following:
-		//#define SET_CURRENT_HACK_00 //OEM configuration (no current hack installed inside MCM)
+		#define SET_CURRENT_HACK_00 //OEM configuration (no current hack installed inside MCM)
 		//#define SET_CURRENT_HACK_20 //+20%
-		#define SET_CURRENT_HACK_40 //+40%
+		//#define SET_CURRENT_HACK_40 //+40%
 		//#define SET_CURRENT_HACK_60 //+60% //Note: LiBCM can only measure between 71 A regen & 147 A assist //higher current values will (safely) rail the ADC
 
 	//choose ONE of the following:
@@ -46,7 +47,7 @@
 
 	#define CELL_VMAX_REGEN       42000 //42000 = 4.2000 volts
 	#define CELL_VMIN_ASSIST      31900 //allows for ESR-based voltage drop
-	#define CELL_VMAX_GRIDCHARGER 41000 //3.9 volts is 75% SoC //other values: See SoC.cpp
+	#define CELL_VMAX_GRIDCHARGER 39000 //3.9 volts is 75% SoC //other values: See SoC.cpp
 	#define CELL_VMIN_GRIDCHARGER 30000 //grid charger will not charge severely empty cells
 	#define CELL_VMIN_KEYOFF      34400 //When car is off, LiBCM turns off below this voltage
 

--- a/Firmware/MVP/config.h
+++ b/Firmware/MVP/config.h
@@ -7,19 +7,18 @@
 	#define config_h
 	#include "libcm.h"  //For Arduino IDE compatibility
 
-	#define FW_VERSION "0.6.2"
-    #define BUILD_DATE "2022JAN20"
+	#define FW_VERSION "0.6.3"
+    #define BUILD_DATE "2022JAN21"
 
 	#define CPU_MAP_MEGA2560
 
     //chose ONE of the following:
-    	//#define HW_REVB
     	#define HW_REVC
 
 	//choose ONE of the following:
-		#define SET_CURRENT_HACK_00 //OEM configuration (no current hack installed inside MCM)
+		//#define SET_CURRENT_HACK_00 //OEM configuration (no current hack installed inside MCM)
 		//#define SET_CURRENT_HACK_20 //+20%
-		//#define SET_CURRENT_HACK_40 //+40%
+		#define SET_CURRENT_HACK_40 //+40%
 		//#define SET_CURRENT_HACK_60 //+60% //Note: LiBCM can only measure between 71 A regen & 147 A assist //higher current values will (safely) rail the ADC
 
 	//choose ONE of the following:
@@ -47,11 +46,11 @@
 
 	#define CELL_VMAX_REGEN       42000 //42000 = 4.2000 volts
 	#define CELL_VMIN_ASSIST      31900 //allows for ESR-based voltage drop
-	#define CELL_VMAX_GRIDCHARGER 39000 //3.9 volts is 75% SoC //other values: See SoC.cpp
+	#define CELL_VMAX_GRIDCHARGER 41000 //3.9 volts is 75% SoC //other values: See SoC.cpp
 	#define CELL_VMIN_GRIDCHARGER 30000 //grid charger will not charge severely empty cells
 	#define CELL_VMIN_KEYOFF      34400 //When car is off, LiBCM turns off below this voltage
 
-	#define LTC68042_ENABLE_C19_VOLTAGE_CORRECTION //Uncomment if using stock Honda EHW5 lithium modules 
+	#define LTC68042_ENABLE_C19_VOLTAGE_CORRECTION //Uncomment if using stock Honda EHW5 lithium modules
 
 	#define STACK_mAh_NOM 5000 //nominal pack size (0:100% SoC) //LiBCM uses this value until it determines the actual pack capacity
 	#define STACK_SoC_MAX 85 //maximum state of charge before regen  is disabled


### PR DESCRIPTION
Once every frame BATTSCI_SoC_Hysteresis() is run and it blends the SoC that LiBCM sends to the MCM so that it only changes by 0.1% increments.

Between key-off and key-on the SoC is recalculated so that it doesn't have to slowly blend to a new value if the pack was grid charged.

I also removed all instances of '!!!' because it was causing upload timeout.  See:
https://forum.arduino.cc/t/string-with-three-exclamations/129738/6