### PR TITLE
Add PR gate gh action for passing builds

### DIFF
--- a/.github/workflows/compile-test.yaml
+++ b/.github/workflows/compile-test.yaml
@@ -1,0 +1,23 @@
+name: PR Tests
+
+on:
+  pull_request:
+    paths:
+      - 'Firmware/**'
+      - '.github/workflows/**'
+
+jobs:
+  compile-test:
+    name: Compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Build
+        uses: arduino/compile-sketches@v1
+        with:
+          cli-version: 0.31.0
+          fqbn: 'arduino:avr:mega'
+          sketch-paths: |
+            - Firmware/MVP/MVP.ino


### PR DESCRIPTION
Adds a github action to run a job on new PRs and any new commits to branches referenced in those PRs for a very quick sanity check on the new code.

Once the PR is opened, you should see the job kick off under the "Actions" tab (maybe, this seems like a security risk so github might initially block this. I haven't tried this across forks before).
**[Update: GH does block this, you'll need to approve it](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)**

Under "Settings", you'll need to add a branch protection rule on the `main` branch to get the PR gate check working. Once the action runs for the first time, pending permissions, you should be able to find a status check named `Compile`. 

<img width="1148" alt="Screen Shot 2023-02-26 at 11 37 50 PM" src="https://user-images.githubusercontent.com/7459562/221477774-07c0b52e-a7c7-4efa-b637-19ee115472f5.png">

<img width="754" alt="Screen Shot 2023-02-26 at 11 39 12 PM" src="https://user-images.githubusercontent.com/7459562/221477694-a76a809a-bf59-4b93-8593-34efbb775fc0.png">

