### PR TITLE
Enabling medium fan speed

### DIFF
--- a/Firmware/MVP/fan.cpp
+++ b/Firmware/MVP/fan.cpp
@@ -7,7 +7,7 @@
 
 #include "libcm.h"
 
-uint8_t fanSpeed_now  = FAN_OFF; //actual fan state now (OFF/LOW/HIGH)
+uint8_t fanSpeed_now  = FAN_OFF; //actual fan state now (OFF/LOW/MED/HIGH)
 uint8_t fanSpeed_goal = FAN_OFF; //desired fan state (highest speed requested by any subsystem)
 
 uint8_t fanSpeed_allRequestors = FAN_FORCE_OFF; //each subsystem's fan speed request is stored in 2 bits (see 'FAN_REQUESTOR' constants)
@@ -191,9 +191,13 @@ void updateFanRequest_battery(void)
 
 void determineFastestFanSpeedRequest(void)
 {
-	if     (fanSpeed_allRequestors & FAN_HI_MASK) { fanSpeed_goal = FAN_HIGH; } //at least one subsystem is requesting high speed
-	else if(fanSpeed_allRequestors & FAN_LO_MASK) { fanSpeed_goal = FAN_LOW;  } //at least one subsystem is requesting low speed
-	else                                          { fanSpeed_goal = FAN_OFF;  } //no subsystem is requesting fan
+	const uint8_t fan_hi_bits = (fanSpeed_allRequestors & FAN_HI_MASK) >> 1; //shift to align with lo_bits
+	const uint8_t fan_lo_bits = (fanSpeed_allRequestors & FAN_LO_MASK);
+
+	if     (fan_hi_bits & fan_lo_bits) { fanSpeed_goal = FAN_HIGH; } //at least one subsystem is requesting high speed
+	else if(fan_hi_bits)               { fanSpeed_goal = FAN_MED;  } //at least one subsystem is requesting medium speed
+	else if(fan_lo_bits)               { fanSpeed_goal = FAN_LOW;  } //at least one subsystem is requesting low speed
+	else                               { fanSpeed_goal = FAN_OFF;  } //no subsystem is requesting fan
 }
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -208,9 +212,7 @@ bool hasEnoughTimePassedToChangeFanSpeed(void)
 
 	if(fanSpeed_goal != fanSpeed_goal_previous)
 	{
-		//JTS2doLater: Add logic for FAN_MED
-		if( ((fanSpeed_goal_previous == FAN_OFF)                               ) || //speed changing from off to either low or high
-			((fanSpeed_goal_previous == FAN_LOW) && (fanSpeed_goal == FAN_HIGH))  ) //speed changing from low to high
+		if(fanSpeed_goal > fanSpeed_goal_previous)
 		{
 			//fan speed goal is increasing
 			if( (millis() - latestFanSpeedChange_ms) < FAN_SPEED_INCREASE_HYSTERESIS_ms ) { hasEnoughTimePassed = NO; }

--- a/Firmware/MVP/fan.cpp
+++ b/Firmware/MVP/fan.cpp
@@ -212,28 +212,17 @@ bool hasEnoughTimePassedToChangeFanSpeed(void)
 
 	if(fanSpeed_goal != fanSpeed_goal_previous)
 	{
-		if(fanSpeed_goal > fanSpeed_goal_previous)
-		{
-			//fan speed goal is increasing
-			if( (millis() - latestFanSpeedChange_ms) < FAN_SPEED_INCREASE_HYSTERESIS_ms ) { hasEnoughTimePassed = NO; }
-			else
-			{
-				// enough time has passed
-				latestFanSpeedChange_ms = millis();
-				fanSpeed_goal_previous = fanSpeed_goal;
-			}
+		const uint32_t hysteresisTarget_ms = (fanSpeed_goal > fanSpeed_goal_previous) ?
+			FAN_SPEED_INCREASE_HYSTERESIS_ms : FAN_SPEED_DECREASE_HYSTERESIS_ms;
 
-		}
+		const uint32_t currentTime_ms = millis();
+
+		if((currentTime_ms - latestFanSpeedChange_ms) < hysteresisTarget_ms) { hasEnoughTimePassed = NO; }
 		else
 		{
-			//fan speed goal is decreasing
-			if( (millis() - latestFanSpeedChange_ms) < FAN_SPEED_DECREASE_HYSTERESIS_ms ) { hasEnoughTimePassed = NO; }
-			else
-			{
-				// enough time has passed
-				latestFanSpeedChange_ms = millis();
-				fanSpeed_goal_previous = fanSpeed_goal;
-			}
+			// enough time has passed
+			latestFanSpeedChange_ms = currentTime_ms;
+			fanSpeed_goal_previous = fanSpeed_goal;
 		}
 	}
 

--- a/Firmware/MVP/fan.h
+++ b/Firmware/MVP/fan.h
@@ -16,8 +16,11 @@
 	//fan request status bits (for each subsystem)
 	#define FAN_OFF  0b00
 	#define FAN_LOW  0b01
-	//#define FAN_MED  0b10 //JTS2doLater: not fully implemented in hasEnoughTimePassedToChangeFanSpeed()
+	#define FAN_MED  0b10
 	#define FAN_HIGH 0b11
+	static_assert((FAN_OFF < FAN_LOW),  "FAN_OFF needs to be less than FAN_LOW");
+	static_assert((FAN_LOW < FAN_MED),  "FAN_LOW needs to be less than FAN_MED");
+	static_assert((FAN_MED < FAN_HIGH), "FAN_MED needs to be less than FAN_HIGH");
 
 	#define FAN_HI_MASK   0b10101010 //OR this mask with fanSpeed_allRequestors to see if any subsystem is requesting high speed fans
 	#define FAN_LO_MASK   0b01010101 //OR this mask with fanSpeed_allRequestors to see if any subsystem is requesting  low speed fans


### PR DESCRIPTION
Added supporting logic that allows `fan_requestSpeed(..., FAN_MED)` to be called if desired in the future