### PR TITLE
Constant Current Voltage Spoofing (VOLTAGE_SPOOFING_LINEAR)

### DIFF
--- a/Firmware/firmwareLiBCM/config.h
+++ b/Firmware/firmwareLiBCM/config.h
@@ -65,6 +65,7 @@
         //#define VOLTAGE_SPOOFING_ASSIST_ONLY_VARIABLE //increase assist power by variably   spoofing pack voltage during assist
         //#define VOLTAGE_SPOOFING_ASSIST_ONLY_BINARY   //increase assist power by statically spoofing pack voltage during heavy assist
         //#define VOLTAGE_SPOOFING_ASSIST_AND_REGEN     //increase assist and regen power by variably spoofing pack voltage //DEPRECATED (regen too strong)
+        //#define VOLTAGE_SPOOFING_LINEAR               //increase assist and regen power by requesting peak current level as per OEM (compatible with 100A fuse)
 
     //48S ignores this parameter (choose any value)
     //60S ONLY: to increase assist power, choose the lowest spoofed voltage that doesn't cause p-codes during heavy assist (e.g. P1440)

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -86,22 +86,22 @@ uint8_t calculate_Vspoof_maxPossible(void)
     uint8_t actualPackVoltage = LTC68042result_packVoltage_get();
     uint8_t maxAllowedVspoof = 0;
 
-	 if      (actualPackVoltage < 109) { maxAllowedVspoof = actualPackVoltage -  6; }
-          else if (actualPackVoltage < 119) { maxAllowedVspoof = actualPackVoltage -  7; }
-          else if (actualPackVoltage < 128) { maxAllowedVspoof = actualPackVoltage -  8; }
-          else if (actualPackVoltage < 138) { maxAllowedVspoof = actualPackVoltage -  9; }
-          else if (actualPackVoltage < 148) { maxAllowedVspoof = actualPackVoltage - 10; }
-          else if (actualPackVoltage < 158) { maxAllowedVspoof = actualPackVoltage - 11; }
-          else if (actualPackVoltage < 167) { maxAllowedVspoof = actualPackVoltage - 12; }
-          else if (actualPackVoltage < 177) { maxAllowedVspoof = actualPackVoltage - 13; }
-          else if (actualPackVoltage < 187) { maxAllowedVspoof = actualPackVoltage - 14; }
-          else if (actualPackVoltage < 197) { maxAllowedVspoof = actualPackVoltage - 15; }
-          else if (actualPackVoltage < 206) { maxAllowedVspoof = actualPackVoltage - 16; }
-          else if (actualPackVoltage < 216) { maxAllowedVspoof = actualPackVoltage - 17; }
-          else if (actualPackVoltage < 226) { maxAllowedVspoof = actualPackVoltage - 18; }
-          else if (actualPackVoltage < 236) { maxAllowedVspoof = actualPackVoltage - 19; }
-          else if (actualPackVoltage < 245) { maxAllowedVspoof = actualPackVoltage - 20; }
-        else                              { maxAllowedVspoof = actualPackVoltage - 21; }
+    if      (actualPackVoltage < 109) { maxAllowedVspoof = actualPackVoltage -  6; }
+    else if (actualPackVoltage < 119) { maxAllowedVspoof = actualPackVoltage -  7; }
+    else if (actualPackVoltage < 128) { maxAllowedVspoof = actualPackVoltage -  8; }
+    else if (actualPackVoltage < 138) { maxAllowedVspoof = actualPackVoltage -  9; }
+    else if (actualPackVoltage < 148) { maxAllowedVspoof = actualPackVoltage - 10; }
+    else if (actualPackVoltage < 158) { maxAllowedVspoof = actualPackVoltage - 11; }
+    else if (actualPackVoltage < 167) { maxAllowedVspoof = actualPackVoltage - 12; }
+    else if (actualPackVoltage < 177) { maxAllowedVspoof = actualPackVoltage - 13; }
+    else if (actualPackVoltage < 187) { maxAllowedVspoof = actualPackVoltage - 14; }
+    else if (actualPackVoltage < 197) { maxAllowedVspoof = actualPackVoltage - 15; }
+    else if (actualPackVoltage < 206) { maxAllowedVspoof = actualPackVoltage - 16; }
+    else if (actualPackVoltage < 216) { maxAllowedVspoof = actualPackVoltage - 17; }
+    else if (actualPackVoltage < 226) { maxAllowedVspoof = actualPackVoltage - 18; }
+    else if (actualPackVoltage < 236) { maxAllowedVspoof = actualPackVoltage - 19; }
+    else if (actualPackVoltage < 245) { maxAllowedVspoof = actualPackVoltage - 20; }
+    else                              { maxAllowedVspoof = actualPackVoltage - 21; }
 
     return maxAllowedVspoof;
 }

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -86,22 +86,12 @@ uint8_t calculate_Vspoof_maxPossible(void)
     uint8_t actualPackVoltage = LTC68042result_packVoltage_get();
     uint8_t maxAllowedVspoof = 0;
 
-    if      (actualPackVoltage < 109) { maxAllowedVspoof = actualPackVoltage -  6; }
-    else if (actualPackVoltage < 119) { maxAllowedVspoof = actualPackVoltage -  7; }
-    else if (actualPackVoltage < 128) { maxAllowedVspoof = actualPackVoltage -  8; }
-    else if (actualPackVoltage < 138) { maxAllowedVspoof = actualPackVoltage -  9; }
-    else if (actualPackVoltage < 148) { maxAllowedVspoof = actualPackVoltage - 10; }
-    else if (actualPackVoltage < 158) { maxAllowedVspoof = actualPackVoltage - 11; }
-    else if (actualPackVoltage < 167) { maxAllowedVspoof = actualPackVoltage - 12; }
-    else if (actualPackVoltage < 177) { maxAllowedVspoof = actualPackVoltage - 13; }
-    else if (actualPackVoltage < 187) { maxAllowedVspoof = actualPackVoltage - 14; }
-    else if (actualPackVoltage < 197) { maxAllowedVspoof = actualPackVoltage - 15; }
-    else if (actualPackVoltage < 206) { maxAllowedVspoof = actualPackVoltage - 16; }
-    else if (actualPackVoltage < 216) { maxAllowedVspoof = actualPackVoltage - 17; }
-    else if (actualPackVoltage < 226) { maxAllowedVspoof = actualPackVoltage - 18; }
-    else if (actualPackVoltage < 236) { maxAllowedVspoof = actualPackVoltage - 19; }
-    else if (actualPackVoltage < 245) { maxAllowedVspoof = actualPackVoltage - 20; }
-    else                              { maxAllowedVspoof = actualPackVoltage - 21; }
+           { maxAllowedVspoof = actualPackVoltage * 0.4 + 72; } 
+		   // adjusts spoof voltage across entire range so that current is 50A continuous, 83A peak
+		   // 48S yields from +19% power
+		   // 60S yields from +28% power
+		   // max spoofing is within 67% of Vpack
+		   // this is compatible with standard 100A OEM fuse.
 
     return maxAllowedVspoof;
 }

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -86,12 +86,22 @@ uint8_t calculate_Vspoof_maxPossible(void)
     uint8_t actualPackVoltage = LTC68042result_packVoltage_get();
     uint8_t maxAllowedVspoof = 0;
 
-           { maxAllowedVspoof = actualPackVoltage * 0.4 + 72; } 
-		   // adjusts spoof voltage across entire range so that current is 50A continuous, 83A peak
-		   // 48S yields from +19% power
-		   // 60S yields from +28% power
-		   // max spoofing is within 67% of Vpack
-		   // this is compatible with standard 100A OEM fuse.
+	 if      (actualPackVoltage < 109) { maxAllowedVspoof = actualPackVoltage -  6; }
+          else if (actualPackVoltage < 119) { maxAllowedVspoof = actualPackVoltage -  7; }
+          else if (actualPackVoltage < 128) { maxAllowedVspoof = actualPackVoltage -  8; }
+          else if (actualPackVoltage < 138) { maxAllowedVspoof = actualPackVoltage -  9; }
+          else if (actualPackVoltage < 148) { maxAllowedVspoof = actualPackVoltage - 10; }
+          else if (actualPackVoltage < 158) { maxAllowedVspoof = actualPackVoltage - 11; }
+          else if (actualPackVoltage < 167) { maxAllowedVspoof = actualPackVoltage - 12; }
+          else if (actualPackVoltage < 177) { maxAllowedVspoof = actualPackVoltage - 13; }
+          else if (actualPackVoltage < 187) { maxAllowedVspoof = actualPackVoltage - 14; }
+          else if (actualPackVoltage < 197) { maxAllowedVspoof = actualPackVoltage - 15; }
+          else if (actualPackVoltage < 206) { maxAllowedVspoof = actualPackVoltage - 16; }
+          else if (actualPackVoltage < 216) { maxAllowedVspoof = actualPackVoltage - 17; }
+          else if (actualPackVoltage < 226) { maxAllowedVspoof = actualPackVoltage - 18; }
+          else if (actualPackVoltage < 236) { maxAllowedVspoof = actualPackVoltage - 19; }
+          else if (actualPackVoltage < 245) { maxAllowedVspoof = actualPackVoltage - 20; }
+        else                              { maxAllowedVspoof = actualPackVoltage - 21; }
 
     return maxAllowedVspoof;
 }
@@ -214,6 +224,18 @@ void spoofVoltage_calculateValue(void)
 
     //---------------------------------------------------------------------------
 
+    #elif defined   VOLTAGE_SPOOFING_LINEAR
+	
+	           spoofedPackVoltage = actualPackVoltage * 0.4 + 72; 
+	
+		   // adjusts spoof voltage across entire range so that current is 50A continuous, 83A peak
+		   // 48S yields from +19% power
+		   // 60S yields from +28% power
+		   // max spoofing is within 67% of Vpack
+		   // this is compatible with standard 100A OEM fuse.
+
+    //---------------------------------------------------------------------------
+	
     #else
         #error (VOLTAGE_SPOOFING value not selected in config.h)
     #endif

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -224,9 +224,9 @@ void spoofVoltage_calculateValue(void)
 
     //---------------------------------------------------------------------------
 
-    #elif defined   VOLTAGE_SPOOFING_LINEAR
+    #elif defined  VOLTAGE_SPOOFING_LINEAR
 	
-	           spoofedPackVoltage = actualPackVoltage * 0.4 + 72; 
+	           spoofedPackVoltage = maxPossibleVspoof * 0.4 + 78; 
 	
 		   // adjusts spoof voltage across entire range so that current is 50A continuous, 83A peak
 		   // 48S yields from +19% power


### PR DESCRIPTION
- adjusts spoof voltage across entire range so that max current is 50A continuous, 83A peak
- 48S yields from +19% power
- 60S yields from +28% power
- max spoofing is within 67% of Vpack
- this is compatible with standard 100A OEM fuse.

Brake regen and assist is now usefully stronger, fully compatible with OEM mode operation. 

"Current hack" modification will further increase the above values and requires a larger main fuse.

This has been tested on a 48S FoMoCo in OEM mode on a 2001 Manual transmission UK insight and works as intended.