### PR TITLE
SOC gauge fix

### DIFF
--- a/Firmware/firmwareLiBCM/src/battsci.cpp
+++ b/Firmware/firmwareLiBCM/src/battsci.cpp
@@ -39,7 +39,7 @@ const uint16_t remap_actualToSpoofedSoC[101] = {
     1000,                                    //LiCBM SoC = 100%
 };  //Data empirically gathered from OEM NiMH IMA system //see ../Firmware/Prototype Building Blocks/Remap SoC.ods for calculations
 
-uint16_t previousOutputSoC_deciPercent = remap_actualToSpoofedSoC[SoC_getBatteryStateNow_percent()];
+uint16_t previousOutputSoC_deciPercent; // leave empty till later
 
 
 /////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is the key change that makes the OEM SOC gauge work.