### PR TITLE
VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG

### DIFF
--- a/Firmware/firmwareLiBCM/config.h
+++ b/Firmware/firmwareLiBCM/config.h
@@ -7,8 +7,8 @@
     #define config_h
     #include "src/libcm.h"
 
-    #define FW_VERSION "0.9.4d"
-    #define BUILD_DATE "2024JUL23"
+    #define FW_VERSION "0.9.4d BD VSPOOF"
+    #define BUILD_DATE "2024SEP15"
 
     //////////////////////////////////////////////////////////////////
 
@@ -65,20 +65,21 @@
     //60S MUST use 'VOLTAGE_SPOOFING_DISABLE':
         #define VOLTAGE_SPOOFING_DISABLE              //spoof maximum possible pack voltage at all times //closest to OEM behavior
         //#define VOLTAGE_SPOOFING_ASSIST_ONLY_VARIABLE //increase assist power by variably   spoofing pack voltage during assist
-        //#define VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG //Bull Dog's experimental variable voltage spoofing for 60S 47AH Conversions. May cause P1440. Only tested with the 20% Current Hack!
         //#define VOLTAGE_SPOOFING_ASSIST_ONLY_BINARY   //increase assist power by statically spoofing pack voltage during heavy assist
         //#define VOLTAGE_SPOOFING_ASSIST_AND_REGEN     //increase assist and regen power by variably spoofing pack voltage //DEPRECATED (regen too strong)
         //#define VOLTAGE_SPOOFING_LINEAR               //increase assist and regen power by requesting peak current level as per OEM (compatible with 100A fuse)
+        //#define VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG //Bull Dog's experimental variable voltage spoofing for 60S 47AH Conversions. May cause P1440. 
 
     //48S ignores this parameter (choose any value)
     //60S ONLY: to increase assist power, choose the lowest spoofed voltage that doesn't cause p-codes during heavy assist (e.g. P1440)
+	//VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG: Set this value to 150. Change to 155 or 160 if P1440s occurs during heavy assist above 2100 RPM. 
         //#define MIN_SPOOFED_VOLTAGE_60S 180 //voltage spoofing related p-codes won't occur in any car
         //#define MIN_SPOOFED_VOLTAGE_60S 175
-        #define MIN_SPOOFED_VOLTAGE_60S 170 //recommended starting value //choose higher voltage if p-codes occur during heavy assist
+        #define MIN_SPOOFED_VOLTAGE_60S 170 //recommended starting value for VOLTAGE_SPOOFING_DISABLE setting.  //choose higher voltage if p-codes occur during heavy assist
         //#define MIN_SPOOFED_VOLTAGE_60S 165
         //#define MIN_SPOOFED_VOLTAGE_60S 160
         //#define MIN_SPOOFED_VOLTAGE_60S 155
-        //#define MIN_SPOOFED_VOLTAGE_60S 150 //voltage spoofing related p-codes will occur in most cars during heavy assist
+        //#define MIN_SPOOFED_VOLTAGE_60S 150 //VOLTAGE_SPOOFING_DISABLE: p-codes will occur in most cars during heavy assist
 
     //////////////////////////////////////////////////////////////////
 

--- a/Firmware/firmwareLiBCM/config.h
+++ b/Firmware/firmwareLiBCM/config.h
@@ -65,6 +65,7 @@
     //60S MUST use 'VOLTAGE_SPOOFING_DISABLE':
         #define VOLTAGE_SPOOFING_DISABLE              //spoof maximum possible pack voltage at all times //closest to OEM behavior
         //#define VOLTAGE_SPOOFING_ASSIST_ONLY_VARIABLE //increase assist power by variably   spoofing pack voltage during assist
+        //#define VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG //Bull Dog's experimental variable voltage spoofing for 60S 47AH Conversions. May cause P1440
         //#define VOLTAGE_SPOOFING_ASSIST_ONLY_BINARY   //increase assist power by statically spoofing pack voltage during heavy assist
         //#define VOLTAGE_SPOOFING_ASSIST_AND_REGEN     //increase assist and regen power by variably spoofing pack voltage //DEPRECATED (regen too strong)
         //#define VOLTAGE_SPOOFING_LINEAR               //increase assist and regen power by requesting peak current level as per OEM (compatible with 100A fuse)

--- a/Firmware/firmwareLiBCM/config.h
+++ b/Firmware/firmwareLiBCM/config.h
@@ -8,7 +8,7 @@
     #include "src/libcm.h"
 
     #define FW_VERSION "0.9.4d BD VSPOOF"
-    #define BUILD_DATE "2024SEP15"
+    #define BUILD_DATE "2024SEP26"
 
     //////////////////////////////////////////////////////////////////
 
@@ -62,24 +62,27 @@
     //modify these parameters if you want more power during heavy assist and/or regen.
 
     //48S ONLY: choose ONE of the following
-    //60S MUST use 'VOLTAGE_SPOOFING_DISABLE':
+    //60S MUST use 'VOLTAGE_SPOOFING_DISABLE' or 'VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG':
+
         #define VOLTAGE_SPOOFING_DISABLE              //spoof maximum possible pack voltage at all times //closest to OEM behavior
         //#define VOLTAGE_SPOOFING_ASSIST_ONLY_VARIABLE //increase assist power by variably   spoofing pack voltage during assist
         //#define VOLTAGE_SPOOFING_ASSIST_ONLY_BINARY   //increase assist power by statically spoofing pack voltage during heavy assist
         //#define VOLTAGE_SPOOFING_ASSIST_AND_REGEN     //increase assist and regen power by variably spoofing pack voltage //DEPRECATED (regen too strong)
         //#define VOLTAGE_SPOOFING_LINEAR               //increase assist and regen power by requesting peak current level as per OEM (compatible with 100A fuse)
-        //#define VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG //Bull Dog's experimental variable voltage spoofing for 60S 47AH Conversions. May cause P1440. 
+        //#define VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG //Bull Dog's variable voltage spoofing for 60S configs. Only apply full assist above 2100 RPM or P1440 will likely occur.
+
 
     //48S ignores this parameter (choose any value)
-    //60S ONLY: to increase assist power, choose the lowest spoofed voltage that doesn't cause p-codes during heavy assist (e.g. P1440)
-	//VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG: Set this value to 150. Change to 155 or 160 if P1440s occurs during heavy assist above 2100 RPM. 
+    //60S:  VOLTAGE_SPOOFING_DISABLE: to increase assist power, choose the lowest spoofed voltage that doesn't cause p-codes during heavy assist (e.g. P1440)
+    //      VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG: Set this value to 150. Change to 155 or 160 if P1440s occurs during heavy assist above 2100 RPM. 
+
         //#define MIN_SPOOFED_VOLTAGE_60S 180 //voltage spoofing related p-codes won't occur in any car
         //#define MIN_SPOOFED_VOLTAGE_60S 175
         #define MIN_SPOOFED_VOLTAGE_60S 170 //recommended starting value for VOLTAGE_SPOOFING_DISABLE setting.  //choose higher voltage if p-codes occur during heavy assist
         //#define MIN_SPOOFED_VOLTAGE_60S 165
         //#define MIN_SPOOFED_VOLTAGE_60S 160
         //#define MIN_SPOOFED_VOLTAGE_60S 155
-        //#define MIN_SPOOFED_VOLTAGE_60S 150 //VOLTAGE_SPOOFING_DISABLE: p-codes will occur in most cars during heavy assist
+        //#define MIN_SPOOFED_VOLTAGE_60S 150 //recommended starting value for VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG. //VOLTAGE_SPOOFING_DISABLE: p-codes will occur in most cars during heavy assist
 
     //////////////////////////////////////////////////////////////////
 

--- a/Firmware/firmwareLiBCM/config.h
+++ b/Firmware/firmwareLiBCM/config.h
@@ -65,7 +65,7 @@
     //60S MUST use 'VOLTAGE_SPOOFING_DISABLE':
         #define VOLTAGE_SPOOFING_DISABLE              //spoof maximum possible pack voltage at all times //closest to OEM behavior
         //#define VOLTAGE_SPOOFING_ASSIST_ONLY_VARIABLE //increase assist power by variably   spoofing pack voltage during assist
-        //#define VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG //Bull Dog's experimental variable voltage spoofing for 60S 47AH Conversions. May cause P1440
+        //#define VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG //Bull Dog's experimental variable voltage spoofing for 60S 47AH Conversions. May cause P1440. Only tested with the 20% Current Hack!
         //#define VOLTAGE_SPOOFING_ASSIST_ONLY_BINARY   //increase assist power by statically spoofing pack voltage during heavy assist
         //#define VOLTAGE_SPOOFING_ASSIST_AND_REGEN     //increase assist and regen power by variably spoofing pack voltage //DEPRECATED (regen too strong)
         //#define VOLTAGE_SPOOFING_LINEAR               //increase assist and regen power by requesting peak current level as per OEM (compatible with 100A fuse)

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -253,13 +253,17 @@ void spoofVoltage_calculateValue(void)
         uint8_t initialSpoofedPackVoltage = 0;
 
         if     ((maxPossibleVspoof < DISABLE_60S_VSPOOF_VOLTAGE)                           || //pack voltage too low
-                (vspoofMCM_max > maxPossibleVspoof)) { initialSpoofedPackVoltage = maxPossibleVspoof; }//If the voltage we want to spoof is greater than maxPossibleVspoof, use maxPossibleVspoof instead.
+                (vspoofMCM_max > maxPossibleVspoof)) { spoofedPackVoltage = maxPossibleVspoof; }//If the voltage we want to spoof is greater than maxPossibleVspoof, use maxPossibleVspoof instead.
             //The above two lines could be simplified. vspoofMCM_max = 184 or maxPossibleVspoof whichever is lower.
 
-        else if (adc_getLatestBatteryCurrent_amps() < BEGIN_SPOOFING_VOLTAGE_ABOVE_AMPS)    { initialSpoofedPackVoltage = vspoofMCM_max; } //regen, idle, or light assist
+        else if (adc_getLatestBatteryCurrent_amps() < BEGIN_SPOOFING_VOLTAGE_ABOVE_AMPS)    { spoofedPackVoltage = vspoofMCM_max; } //regen, idle, or light assist
         
 		//Assist Spoofing
-        else if (adc_getLatestBatteryCurrent_amps() > MAXIMIZE_POWER_ABOVE_CURRENT_AMPS)    { initialSpoofedPackVoltage = LTC68042result_packVoltage_get() * 0.68;} //heavy assist
+        else if (adc_getLatestBatteryCurrent_amps() > MAXIMIZE_POWER_ABOVE_CURRENT_AMPS)    { initialSpoofedPackVoltage = LTC68042result_packVoltage_get() * 0.68;
+			if (initialSpoofedPackVoltage < 145) {spoofedPackVoltage = 145;}  //Limit the minimum spoofed voltage. This may prevent P1440s.
+			else {spoofedPackVoltage = initialSpoofedPackVoltage;}
+		
+		} //heavy assist
         
         else
         {
@@ -284,11 +288,13 @@ void spoofVoltage_calculateValue(void)
 
             //Calculate spoofed pack voltage
             uint8_t initialSpoofedPackVoltage = vspoofMCM_max - packVoltageReduction_V;
+			
+			if (initialSpoofedPackVoltage < 145) {spoofedPackVoltage = 145;}  //Limit the minimum spoofed voltage. This may prevent P1440s.
+			else {spoofedPackVoltage = initialSpoofedPackVoltage;}
 
         }
         
-        if (initialSpoofedPackVoltage < 145) {spoofedPackVoltage = 145;}  //Limit the minimum spoofed voltage. This may prevent P1440s.
-        else {spoofedPackVoltage = initialSpoofedPackVoltage;}
+
    
     //---------------------------------------------------------------------------
 

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -131,7 +131,7 @@ uint8_t calculate_vspoofMCM_max(void)
 void spoofVoltage_calculateValue(void)
 {
     uint8_t maxPossibleVspoof = calculate_Vspoof_maxPossible();
-    
+
     #if defined VOLTAGE_SPOOFING_DISABLE
         //For those that don't want variable voltage spoofing, spoof maximum possible pack voltage
         
@@ -250,7 +250,7 @@ void spoofVoltage_calculateValue(void)
         #endif
 
         uint8_t vspoofMCM_max = calculate_vspoofMCM_max();
-        
+
         if     ((maxPossibleVspoof < VSPOOF_60S_DISABLE_VOLTAGE)                           || //pack voltage too low
                 (vspoofMCM_max > maxPossibleVspoof)) { spoofedPackVoltage = maxPossibleVspoof; }//If the voltage we want to spoof is greater than maxPossibleVspoof, use maxPossibleVspoof instead.
             //The above two lines could be simplified. vspoofMCM_max = 184 or maxPossibleVspoof whichever is lower.

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -258,7 +258,12 @@ void spoofVoltage_calculateValue(void)
         else if (adc_getLatestBatteryCurrent_amps() < BEGIN_SPOOFING_VOLTAGE_ABOVE_AMPS)    { spoofedPackVoltage = vspoofMCM_max; } //regen, idle, or light assist
         
 		//Assist Spoofing
-        else if (adc_getLatestBatteryCurrent_amps() > MAXIMIZE_POWER_ABOVE_CURRENT_AMPS)    { spoofedPackVoltage = LTC68042result_packVoltage_get() * 0.68; } //heavy assist
+        else if (adc_getLatestBatteryCurrent_amps() > MAXIMIZE_POWER_ABOVE_CURRENT_AMPS)    { spoofedPackVoltage = LTC68042result_packVoltage_get() * 0.68; 
+        
+        if (spoofedPackVoltage < 165) {spoofedPackVoltage = 165;}
+
+        } //heavy assist
+        
         else
         {
             //medium assist
@@ -281,7 +286,10 @@ void spoofVoltage_calculateValue(void)
             uint16_t packVoltageReduction_V  = ((adc_getLatestBatteryCurrent_amps() - BEGIN_SPOOFING_VOLTAGE_ABOVE_AMPS) * voltageAdjustment_mV_per_A) * 0.001;
 
             //Calculate spoofed pack voltage
-            spoofedPackVoltage = vspoofMCM_max - packVoltageReduction_V;
+            uint8_t spoofedPackVoltage = vspoofMCM_max - packVoltageReduction_V;
+
+            if (spoofedPackVoltage < 165) {spoofedPackVoltage = 165;}
+
         }
    
     //---------------------------------------------------------------------------

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -116,7 +116,7 @@ uint8_t calculate_vspoofMCM_max(void)
 {
     //Keep the MCM Happy by Spoofing no higher than 184 Volts for 60s.
     //When maxAllowedVspoof is less than 184 volts, use maxAllowedVspoof instead.
-    //i.e. 
+    
     uint8_t maxAllowedVspoof = calculate_Vspoof_maxPossible();
     uint8_t vspoofMCM_max = 0;
 
@@ -254,20 +254,19 @@ void spoofVoltage_calculateValue(void)
 
         if     ((maxPossibleVspoof < DISABLE_60S_VSPOOF_VOLTAGE)                           || //pack voltage too low
                 (vspoofMCM_max > maxPossibleVspoof)) { spoofedPackVoltage = maxPossibleVspoof; }//If the voltage we want to spoof is greater than maxPossibleVspoof, use maxPossibleVspoof instead.
-            //The above two lines could be simplified. vspoofMCM_max = 184 or maxPossibleVspoof whichever is lower.
 
         else if (adc_getLatestBatteryCurrent_amps() < BEGIN_SPOOFING_VOLTAGE_ABOVE_AMPS)    { spoofedPackVoltage = vspoofMCM_max; } //regen, idle, or light assist
         
 		//Assist Spoofing
         else if (adc_getLatestBatteryCurrent_amps() > MAXIMIZE_POWER_ABOVE_CURRENT_AMPS)    
         { 
-            initialSpoofedPackVoltage = LTC68042result_packVoltage_get() * 0.68;
+            initialSpoofedPackVoltage = LTC68042result_packVoltage_get() * 0.68;  //heavy assist
 
             //Limit the minimum spoofed voltage. This helps prevent P1440s from happening for Balto.
 			if (initialSpoofedPackVoltage < MIN_SPOOFED_VOLTAGE_60S) {spoofedPackVoltage = MIN_SPOOFED_VOLTAGE_60S;}  
 			else {spoofedPackVoltage = initialSpoofedPackVoltage;}
 		
-		} //heavy assist
+		} 
         
         else
         {

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -251,7 +251,7 @@ void spoofVoltage_calculateValue(void)
 
         uint8_t vspoofMCM_max = calculate_vspoofMCM_max();
 
-        if     ((maxPossibleVspoof < VSPOOF_60S_DISABLE_VOLTAGE)                           || //pack voltage too low
+        if     ((maxPossibleVspoof < DISABLE_60S_VSPOOF_VOLTAGE)                           || //pack voltage too low
                 (vspoofMCM_max > maxPossibleVspoof)) { spoofedPackVoltage = maxPossibleVspoof; }//If the voltage we want to spoof is greater than maxPossibleVspoof, use maxPossibleVspoof instead.
             //The above two lines could be simplified. vspoofMCM_max = 184 or maxPossibleVspoof whichever is lower.
 

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -131,7 +131,7 @@ uint8_t calculate_vspoofMCM_max(void)
 void spoofVoltage_calculateValue(void)
 {
     uint8_t maxPossibleVspoof = calculate_Vspoof_maxPossible();
-
+    
     #if defined VOLTAGE_SPOOFING_DISABLE
         //For those that don't want variable voltage spoofing, spoof maximum possible pack voltage
         
@@ -249,6 +249,8 @@ void spoofVoltage_calculateValue(void)
             #error (VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG only works with 60S config.)
         #endif
 
+        uint8_t vspoofMCM_max = calculate_vspoofMCM_max();
+        
         if     ((maxPossibleVspoof < VSPOOF_60S_DISABLE_VOLTAGE)                           || //pack voltage too low
                 (vspoofMCM_max > maxPossibleVspoof)) { spoofedPackVoltage = maxPossibleVspoof; }//If the voltage we want to spoof is greater than maxPossibleVspoof, use maxPossibleVspoof instead.
             //The above two lines could be simplified. vspoofMCM_max = 184 or maxPossibleVspoof whichever is lower.

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -112,6 +112,22 @@ uint8_t calculate_Vspoof_maxPossible(void)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+uint8_t calculate_vspoofMCM_max(void)
+{
+    //Keep the MCM Happy by Spoofing no higher than 184 Volts for 60s.
+    //When maxAllowedVspoof is less than 184 volts, use maxAllowedVspoof instead.
+    //i.e. 
+    uint8_t maxAllowedVspoof = calculate_Vspoof_maxPossible();
+    uint8_t vspoofMCM_max = 0;
+
+    if      (maxAllowedVspoof < 184) { vspoofMCM_max = maxAllowedVspoof; }
+    else                              { vspoofMCM_max = 184; }
+
+    return vspoofMCM_max;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
 void spoofVoltage_calculateValue(void)
 {
     uint8_t maxPossibleVspoof = calculate_Vspoof_maxPossible();
@@ -227,6 +243,47 @@ void spoofVoltage_calculateValue(void)
         }
 
     //---------------------------------------------------------------------------
+
+	#elif defined   VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG
+            #ifdef STACK_IS_48S
+            #error (VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG only works with 60S config.)
+        #endif
+
+        if     ((maxPossibleVspoof < VSPOOF_60S_DISABLE_VOLTAGE)                           || //pack voltage too low
+                (vspoofMCM_max > maxPossibleVspoof)) { spoofedPackVoltage = maxPossibleVspoof; }//If the voltage we want to spoof is greater than maxPossibleVspoof, use maxPossibleVspoof instead.
+            //The above two lines could be simplified. vspoofMCM_max = 184 or maxPossibleVspoof whichever is lower.
+
+        else if (adc_getLatestBatteryCurrent_amps() < BEGIN_SPOOFING_VOLTAGE_ABOVE_AMPS)    { spoofedPackVoltage = vspoofMCM_max; } //regen, idle, or light assist
+        
+		//Assist Spoofing
+        else if (adc_getLatestBatteryCurrent_amps() > MAXIMIZE_POWER_ABOVE_CURRENT_AMPS)    { spoofedPackVoltage = LTC68042result_packVoltage_get() * 0.68; } //heavy assist
+        else
+        {
+            //medium assist
+            //decrease spoofedPackVoltage inversely proportional to assist current
+
+            uint8_t vAdjustRange_V = vspoofMCM_max - (LTC68042result_packVoltage_get() * 0.68);
+
+            //Calculate voltage adjustment per amp assist
+            //       voltageAdjustment_mV_per_A =            vAdjustRange_V   * 1000  / ADDITIONAL_AMPS_UNTIL_MAX_VSPOOF;
+            //       voltageAdjustment_mV_per_A =            vAdjustRange_V   * 1024  / ADDITIONAL_AMPS_UNTIL_MAX_VSPOOF; //change multiply to 2^n (2.4% error)
+            //       voltageAdjustment_mV_per_A =            vAdjustRange_V  <<   10 >> ADDITIONAL_AMPS__2_TO_THE_N     ; //substitute mult/div with bit shifts
+            //       voltageAdjustment_mV_per_A =            vAdjustRange_V  <<  (10  - ADDITIONAL_AMPS__2_TO_THE_N)    ; //combine bit shifts
+            uint16_t voltageAdjustment_mV_per_A = ((uint16_t)vAdjustRange_V) <<  (10  - ADDITIONAL_AMPS__2_TO_THE_N)    ; //cast intermediate math
+            //max counts: 3712 (when 60S pack is 4.3 V/cell)
+            //min counts:    0 (when 48S pack is 2.7 V/cell) 
+
+            //Calculate how much to reduce actual pack voltage at any current
+            //      packVoltageReduction_mV =  (actualCurrent_A                    - BEGIN_SPOOFING_VOLTAGE_ABOVE_AMPS) * voltageAdjustment_mV_per_A         ;
+            //      packVoltageReduction_V  =  (actualCurrent_A                    - BEGIN_SPOOFING_VOLTAGE_ABOVE_AMPS) * voltageAdjustment_mV_per_A  * 0.001; //change mV to V
+            uint16_t packVoltageReduction_V  = ((adc_getLatestBatteryCurrent_amps() - BEGIN_SPOOFING_VOLTAGE_ABOVE_AMPS) * voltageAdjustment_mV_per_A) * 0.001;
+
+            //Calculate spoofed pack voltage
+            spoofedPackVoltage = vspoofMCM_max - packVoltageReduction_V;
+        }
+   
+    //---------------------------------------------------------------------------
+
 
     #elif defined  VOLTAGE_SPOOFING_LINEAR
 	

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -264,7 +264,7 @@ void spoofVoltage_calculateValue(void)
             initialSpoofedPackVoltage = LTC68042result_packVoltage_get() * 0.68;
 
             //Limit the minimum spoofed voltage. This helps prevent P1440s from happening for Balto.
-			if (initialSpoofedPackVoltage < VSPOOF60S_MINIMUM_VOLTAGE) {spoofedPackVoltage = VSPOOF60S_MINIMUM_VOLTAGE;}  
+			if (initialSpoofedPackVoltage < MIN_SPOOFED_VOLTAGE_60S) {spoofedPackVoltage = MIN_SPOOFED_VOLTAGE_60S;}  
 			else {spoofedPackVoltage = initialSpoofedPackVoltage;}
 		
 		} //heavy assist
@@ -294,7 +294,7 @@ void spoofVoltage_calculateValue(void)
             uint8_t initialSpoofedPackVoltage = vspoofMCM_max - packVoltageReduction_V;
 			
             //Limit the minimum spoofed voltage.
-			if (initialSpoofedPackVoltage < VSPOOF60S_MINIMUM_VOLTAGE) {spoofedPackVoltage = VSPOOF60S_MINIMUM_VOLTAGE;}  
+			if (initialSpoofedPackVoltage < MIN_SPOOFED_VOLTAGE_60S) {spoofedPackVoltage = MIN_SPOOFED_VOLTAGE_60S;}  
 			else {spoofedPackVoltage = initialSpoofedPackVoltage;}
 
         }

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.cpp
@@ -259,8 +259,12 @@ void spoofVoltage_calculateValue(void)
         else if (adc_getLatestBatteryCurrent_amps() < BEGIN_SPOOFING_VOLTAGE_ABOVE_AMPS)    { spoofedPackVoltage = vspoofMCM_max; } //regen, idle, or light assist
         
 		//Assist Spoofing
-        else if (adc_getLatestBatteryCurrent_amps() > MAXIMIZE_POWER_ABOVE_CURRENT_AMPS)    { initialSpoofedPackVoltage = LTC68042result_packVoltage_get() * 0.68;
-			if (initialSpoofedPackVoltage < 145) {spoofedPackVoltage = 145;}  //Limit the minimum spoofed voltage. This may prevent P1440s.
+        else if (adc_getLatestBatteryCurrent_amps() > MAXIMIZE_POWER_ABOVE_CURRENT_AMPS)    
+        { 
+            initialSpoofedPackVoltage = LTC68042result_packVoltage_get() * 0.68;
+
+            //Limit the minimum spoofed voltage. This helps prevent P1440s from happening for Balto.
+			if (initialSpoofedPackVoltage < VSPOOF60S_MINIMUM_VOLTAGE) {spoofedPackVoltage = VSPOOF60S_MINIMUM_VOLTAGE;}  
 			else {spoofedPackVoltage = initialSpoofedPackVoltage;}
 		
 		} //heavy assist
@@ -289,7 +293,8 @@ void spoofVoltage_calculateValue(void)
             //Calculate spoofed pack voltage
             uint8_t initialSpoofedPackVoltage = vspoofMCM_max - packVoltageReduction_V;
 			
-			if (initialSpoofedPackVoltage < 145) {spoofedPackVoltage = 145;}  //Limit the minimum spoofed voltage. This may prevent P1440s.
+            //Limit the minimum spoofed voltage.
+			if (initialSpoofedPackVoltage < VSPOOF60S_MINIMUM_VOLTAGE) {spoofedPackVoltage = VSPOOF60S_MINIMUM_VOLTAGE;}  
 			else {spoofedPackVoltage = initialSpoofedPackVoltage;}
 
         }

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.h
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.h
@@ -17,7 +17,8 @@
 
     #define VSPOOF_TO_MAXIMIZE_POWER 125 //Maximum assist occurs when MCM thinks pack is at 120 volts
     
-    #define VSPOOF_60S_DISABLE_VOLTAGE 170 //Disable voltage spoofing if maxPossibleVspoof drops below a specificed voltage. 
+    #define DISABLE_60S_VSPOOF_VOLTAGE 177 //Disable voltage spoofing if maxPossibleVspoof drops below a specificed voltage.
+        //When maxPossibleVspoof = 177, pack voltage is 192, or 3.2 volts/cell. 
     
     #define ADDITIONAL_VPIN_OFFSET_VOLTS 0 //this many volts are added to VPIN output //use with OBDIIC&C to make BATTSCI voltage equal to VPIN voltage
     #define ADDITIONAL_MCMe_OFFSET_VOLTS 0 //this many volts are added to MCMe output //use with OBDIIC&C to make BATTSCI voltage equal to MCMe voltage

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.h
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.h
@@ -17,8 +17,9 @@
 
     #define VSPOOF_TO_MAXIMIZE_POWER 125 //Maximum assist occurs when MCM thinks pack is at 120 volts
     
-    #define DISABLE_60S_VSPOOF_VOLTAGE 177 //Disable voltage spoofing if maxPossibleVspoof drops below a specificed voltage.
-        //When maxPossibleVspoof = 177, pack voltage is 192, or 3.2 volts/cell. 
+    #define VSPOOF60S_MINIMUM_VOLTAGE 145 //The minimum voltage to spoof using Bull Dog's 60S VSPOOF profile. If you get a P1440 at lower SoCs, adjust this up to 150.
+    #define DISABLE_60S_VSPOOF_VOLTAGE 172 //Disable voltage spoofing if maxPossibleVspoof drops below a specificed voltage. 172 = pack voltage of 186, or 3.1 volts/cell.
+        
     
     #define ADDITIONAL_VPIN_OFFSET_VOLTS 0 //this many volts are added to VPIN output //use with OBDIIC&C to make BATTSCI voltage equal to VPIN voltage
     #define ADDITIONAL_MCMe_OFFSET_VOLTS 0 //this many volts are added to MCMe output //use with OBDIIC&C to make BATTSCI voltage equal to MCMe voltage

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.h
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.h
@@ -17,7 +17,6 @@
 
     #define VSPOOF_TO_MAXIMIZE_POWER 125 //Maximum assist occurs when MCM thinks pack is at 120 volts
     
-    #define VSPOOF60S_MINIMUM_VOLTAGE 150 //The minimum voltage to spoof using Bull Dog's 60S VSPOOF profile. If you get a P1440 at lower SoCs, adjust this value higher.
     #define DISABLE_60S_VSPOOF_VOLTAGE 172 //Disable voltage spoofing if maxPossibleVspoof drops below a specificed voltage. 172 = pack voltage of 186, or 3.1 volts/cell.
         
     

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.h
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.h
@@ -17,6 +17,8 @@
 
     #define VSPOOF_TO_MAXIMIZE_POWER 125 //Maximum assist occurs when MCM thinks pack is at 120 volts
     
+    #define VSPOOF_60S_DISABLE_VOLTAGE 170 //Disable voltage spoofing if maxPossibleVspoof drops below a specificed voltage. 
+    
     #define ADDITIONAL_VPIN_OFFSET_VOLTS 0 //this many volts are added to VPIN output //use with OBDIIC&C to make BATTSCI voltage equal to VPIN voltage
     #define ADDITIONAL_MCMe_OFFSET_VOLTS 0 //this many volts are added to MCMe output //use with OBDIIC&C to make BATTSCI voltage equal to MCMe voltage
 

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.h
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.h
@@ -17,7 +17,7 @@
 
     #define VSPOOF_TO_MAXIMIZE_POWER 125 //Maximum assist occurs when MCM thinks pack is at 120 volts
     
-    #define VSPOOF60S_MINIMUM_VOLTAGE 150 //The minimum voltage to spoof using Bull Dog's 60S VSPOOF profile. If you get a P1440 at lower SoCs, adjust this up to 150.
+    #define VSPOOF60S_MINIMUM_VOLTAGE 150 //The minimum voltage to spoof using Bull Dog's 60S VSPOOF profile. If you get a P1440 at lower SoCs, adjust this value higher.
     #define DISABLE_60S_VSPOOF_VOLTAGE 172 //Disable voltage spoofing if maxPossibleVspoof drops below a specificed voltage. 172 = pack voltage of 186, or 3.1 volts/cell.
         
     

--- a/Firmware/firmwareLiBCM/src/vPackSpoof.h
+++ b/Firmware/firmwareLiBCM/src/vPackSpoof.h
@@ -17,7 +17,7 @@
 
     #define VSPOOF_TO_MAXIMIZE_POWER 125 //Maximum assist occurs when MCM thinks pack is at 120 volts
     
-    #define VSPOOF60S_MINIMUM_VOLTAGE 145 //The minimum voltage to spoof using Bull Dog's 60S VSPOOF profile. If you get a P1440 at lower SoCs, adjust this up to 150.
+    #define VSPOOF60S_MINIMUM_VOLTAGE 150 //The minimum voltage to spoof using Bull Dog's 60S VSPOOF profile. If you get a P1440 at lower SoCs, adjust this up to 150.
     #define DISABLE_60S_VSPOOF_VOLTAGE 172 //Disable voltage spoofing if maxPossibleVspoof drops below a specificed voltage. 172 = pack voltage of 186, or 3.1 volts/cell.
         
     


### PR DESCRIPTION
VOLTAGE_SPOOFING_VARIABLE_60S_BULL_DOG adds variable voltage spoofing for 60s pack configurations. Trick your MCM into delivering more power today!

20-21 kW with the 20% Current Hack.
24-25 kW with the 40% Current Hack.