### PR TITLE
FoMoCo battery type thermistor remap

### DIFF
--- a/Firmware/firmwareLiBCM/src/cpu_map.h
+++ b/Firmware/firmwareLiBCM/src/cpu_map.h
@@ -10,12 +10,12 @@
     #define CPU_MAP_MEGA2560
 
     #ifdef CPU_MAP_MEGA2560
-    
+
         #define PIN_BATTCURRENT A0
         #define PIN_USER_SW     A1
         #define PIN_VPIN_IN     A2
-        #define PIN_TEMP_YEL    A3
-        #define PIN_TEMP_GRN    A4
+        #define PIN_TEMP_YEL    A3 // 5AhG3: Exhaust, FoMoCo Top middle battery module
+        #define PIN_TEMP_GRN    A4 // 5AhG3: Intake, FoMoCo Top rear battery module
         #define PIN_TEMP_WHT    A5
         #define PIN_TEMP_BLU    A6
         #define PIN_FANOEM_LOW  A7
@@ -48,7 +48,7 @@
         #define PIN_BATTSCI_DE     41
         #define PIN_COVER_SWITCH   42
         #define PIN_GPIO0_CS_MIMA  43
-        #define PIN_GPIO3          44 //with daughterboard: 1500W charger current (if installed) //without daughterboard: heater (if installed) 
+        #define PIN_GPIO3          44 //with daughterboard: 1500W charger current (if installed) //without daughterboard: heater (if installed)
         #define PIN_BUZZER_PWM     45
         #define PIN_LED3           46
         #define PIN_SPI_EXT_CS     47

--- a/Firmware/firmwareLiBCM/src/debugUSB.cpp
+++ b/Firmware/firmwareLiBCM/src/debugUSB.cpp
@@ -193,11 +193,19 @@ void debugUSB_printData_temperatures(void)
     Serial.print(F(", T_in:"));
     Serial.print(String(temperature_intake_getLatest()));
     Serial.print(F(", T_out:"));
+  #ifndef BATTERY_TYPE_47AhFoMoCo
     Serial.print(String(temperature_exhaust_getLatest()));
+  #else
+    Serial.print(F("none"));
+  #endif
     Serial.print(F(", T_charger:"));
     Serial.print(String(temperature_gridCharger_getLatest()));
     Serial.print(F(", T_bay:"));
+  #ifndef BATTERY_TYPE_47AhFoMoCo
     Serial.print(String(temperature_ambient_getLatest()));
+  #else
+    Serial.print(F("none"));
+  #endif
     Serial.print('C');
 }
 

--- a/Firmware/firmwareLiBCM/src/energy.cpp
+++ b/Firmware/firmwareLiBCM/src/energy.cpp
@@ -8,7 +8,7 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-void energy_integrate_centiJoules(void);
+void energy_integrate_centiJoules(void)
 {
 	static uint32_t timestamp_lastCall_ms = 0;
 

--- a/Firmware/firmwareLiBCM/src/gridCharger.cpp
+++ b/Firmware/firmwareLiBCM/src/gridCharger.cpp
@@ -24,10 +24,14 @@ void runFansIfNeeded(void)
     else if (fan_getSpeed_now() == FAN_OFF ) { hysteresis_C = FAN_SPEED_HYSTERESIS_OFF_degC;  }
 
     if      ( (temperature_intake_getLatest()  < (GRID_CHARGING_FANS_OFF_BELOW_TEMP_C - hysteresis_C)) &&
+  #ifndef BATTERY_TYPE_47AhFoMoCo
               (temperature_ambient_getLatest() < (GRID_CHARGING_FANS_OFF_BELOW_TEMP_C - hysteresis_C)) &&
+  #endif
               (temperature_battery_getLatest() < (GRID_CHARGING_FANS_OFF_BELOW_TEMP_C - hysteresis_C))  ) { fan_requestSpeed(FAN_REQUESTOR_GRIDCHARGER, FAN_OFF);  }
     else if ( (temperature_intake_getLatest()  < (GRID_CHARGING_FANS_LOW_BELOW_TEMP_C - hysteresis_C)) &&
+  #ifndef BATTERY_TYPE_47AhFoMoCo
               (temperature_ambient_getLatest() < (GRID_CHARGING_FANS_LOW_BELOW_TEMP_C - hysteresis_C)) &&
+  #endif
               (temperature_battery_getLatest() < (GRID_CHARGING_FANS_LOW_BELOW_TEMP_C - hysteresis_C))  ) { fan_requestSpeed(FAN_REQUESTOR_GRIDCHARGER, FAN_LOW);  }
     else                                                                                                  { fan_requestSpeed(FAN_REQUESTOR_GRIDCHARGER, FAN_HIGH); }
 }
@@ -61,7 +65,9 @@ uint8_t gridCharger_isAllowedNow(void)
     if (temperature_battery_getLatest()      > DISABLE_GRIDCHARGING_ABOVE_BATTERY_TEMP_C) { return NO__BATTERY_IS_HOT;          }
     if (temperature_intake_getLatest()       > DISABLE_GRIDCHARGING_ABOVE_INTAKE_TEMP_C ) { return NO__AIRINTAKE_IS_HOT;        }
     if (temperature_intake_getLatest()      == TEMPERATURE_SENSOR_FAULT_LO              ) { return NO__TEMP_UNPLUGGED_INTAKE;   }
+  #ifndef BATTERY_TYPE_47AhFoMoCo
     if (temperature_exhaust_getLatest()      > DISABLE_GRIDCHARGING_ABOVE_EXHAUST_TEMP_C) { return NO__TEMP_EXHAUST_IS_HOT;     }
+  #endif
     //time checks
     if ((millis()                          ) < DISABLE_GRIDCHARGING_LIBCM_BOOT_DELAY_ms ) { return NO__LIBCM_JUST_BOOTED;         }
     if ((millis() - latestPlugin_ms        ) < DISABLE_GRIDCHARGING_PLUGIN_DELAY_ms     ) { return NO__JUST_PLUGGED_IN;           }

--- a/Firmware/firmwareLiBCM/src/temperature.h
+++ b/Firmware/firmwareLiBCM/src/temperature.h
@@ -6,15 +6,17 @@
 
     int8_t temperature_battery_getLatest(void);
     int8_t temperature_intake_getLatest(void);
-    int8_t temperature_exhaust_getLatest(void);
     int8_t temperature_gridCharger_getLatest(void);
+  #ifndef BATTERY_TYPE_47AhFoMoCo
+    int8_t temperature_exhaust_getLatest(void);
     int8_t temperature_ambient_getLatest(void); //IMA bay temperature
+  #endif
 
     int8_t temperature_measureOneSensor_degC(uint8_t thermistorPin);
 
     void temperature_measureAndPrintAll(void);
     void temperature_printAll_latest(void);
-    
+
     int8_t temperature_coolBatteryAbove_C(void);
     int8_t temperature_heatBatteryBelow_C(void);
 
@@ -25,7 +27,7 @@
     #define TEMPERATURE_PACK_IN_THERMAL_RUNAWAY 70
 
     #define TEMPSENSORSTATE_OFF      1
-    #define TEMPSENSORSTATE_TURNON   2  
+    #define TEMPSENSORSTATE_TURNON   2
     #define TEMPSENSORSTATE_POWERUP  4
     #define TEMPSENSORSTATE_MEASURE  8
     #define TEMPSENSORSTATE_STAYON  16
@@ -34,7 +36,12 @@
     #define ROOM_TEMP_DEGC     23
     #define TEMP_FREEZING_DEGC  0
 
+  #ifdef BATTERY_TYPE_5AhG3
     #define NUM_BATTERY_TEMP_SENSORS 3
+  #elif defined BATTERY_TYPE_47AhFoMoCo
+    // what were 2 OEM temp sensors (PIN_TEMP_GRN, PIN_TEMP_YEL) are now on battery modules
+    #define NUM_BATTERY_TEMP_SENSORS 5
+  #endif
 
     #define TEMP_POWERUP_DELAY_ms 100
 


### PR DESCRIPTION
This aligns firmware thermistor use with the hardware. For the FoMoCo battery type, this is the thermistor use:
 
OEM GRN: IMA Intake (5AhG3 battery) --> Top rear battery module (FoMoCo battery)
OEM YEL:  IMA Exhaust (5AhG3 battery) --> Top middle battery module (FoMoCo battery)
OEM WHT: Ambient (5AhG3 battery) -->  IMA Intake (FoMoCo battery)

With the change, (for the FoMoCo battery type) the OEM GRN and YEL thermistors now participate in temperature_measureBattery(), and no longer in temperature_measureOEM(). Additionally, in the FoMoCo case, there are no explicit Exhaust and Ambient thermistors, so references to these are removed.