### PR TITLE
Change LTC68042cell_nextVoltages() to avoid possible stale data, take 2

### DIFF
--- a/Firmware/firmwareLiBCM/src/BringupTester.cpp
+++ b/Firmware/firmwareLiBCM/src/BringupTester.cpp
@@ -270,6 +270,7 @@ bool testDischargeFETs(void)
         delay(500); //wait for filter network to settle
 
         LTC68042cell_acquireAllCellVoltages();
+        LTC68042cell_acquireAllCellVoltages();
 
         for (uint8_t ii=0; ii<TOTAL_IC; ii++) { debugUSB_printOneICsCellVoltages( ii, 3); }
     }

--- a/Firmware/firmwareLiBCM/src/BringupTester.cpp
+++ b/Firmware/firmwareLiBCM/src/BringupTester.cpp
@@ -8,7 +8,7 @@
 //////////////////////////////////////////////////////////////////
 
 void serialUSB_waitForEmptyBuffer(void)
-{   
+{
     //send all buffered serial data before starting each test (in case of brownout/reset)
     while (Serial.availableForWrite() != 63) { ; } //do nothing
 }
@@ -42,7 +42,7 @@ void bringupTester_gridcharger(void)
 {
     #ifdef RUN_BRINGUP_TESTER_GRIDCHARGER
         while (1) //this function never returns
-        {       
+        {
             Serial.print(F("\nRunning Grid Charger Test: "));
             #ifdef GRIDCHARGER_IS_1500W
                 Serial.print(F("GRIDCHARGER_IS_1500W"));
@@ -204,7 +204,7 @@ bool testLTC6804isoSPI(void)
     delay(50);
 
     Serial.print(F("\nLTC6804 - VREF test: "));
-    if (LTC6804gpio_areAllVoltageReferencesPassing() == true) { Serial.print(F("\nresult: passed")); } 
+    if (LTC6804gpio_areAllVoltageReferencesPassing() == true) { Serial.print(F("\nresult: passed")); }
     else                                                      { Serial.print(F("\nresult: FAIL!! !! !! !!")); didTestFail = true; }
 
     for (int ii=0; ii<5; ii++) { LTC68042cell_acquireAllCellVoltages(); delay(10); } //generate isoSPI traffic to check for errors
@@ -266,17 +266,16 @@ bool testDischargeFETs(void)
         {
             LTC68042configure_setBalanceResistors(FIRST_IC_ADDR + ii, cellDischargeBitmaps[bitmapPattern], LTC6804_DISCHARGE_TIMEOUT_02_SECONDS);
         }
-            
+
         delay(500); //wait for filter network to settle
 
-        LTC68042cell_acquireAllCellVoltages();
         LTC68042cell_acquireAllCellVoltages();
 
         for (uint8_t ii=0; ii<TOTAL_IC; ii++) { debugUSB_printOneICsCellVoltages( ii, 3); }
     }
 
     return didTestFail;
-    
+
     //JTS2do: Automate test results.
     //right now you must paste the results into the following spreadsheet and verify everything is working properly:
     //~/Honda_Insight_LiBCM/Test Fixtures/LTC6804 Discharge Tester Analysis.ods
@@ -290,11 +289,11 @@ bool testLiDisplayLoopback(void)
 
     Serial.print(F("\nLiDisplay loopback test: "));
     serialUSB_waitForEmptyBuffer();
-        
+
     Serial1.begin(57600,SERIAL_8N1);
 
     while (Serial1.available() != 0) { Serial1.read(); } //empty buffer
-    
+
     for (char charToLoopback = 'A'; charToLoopback <= 'Z'; charToLoopback++)
     {
         Serial1.write(charToLoopback);

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -319,10 +319,8 @@ bool LTC68042cell_nextVoltages(void)
 
 //Only call when keyOFF //takes too long to execute when keyON (causes check engine light)
 //Results are stored in "LTC68042_results.c"
-//JTS2doNext: rewrite to remove double call hack
 void LTC68042cell_acquireAllCellVoltages(void)
 {
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //clear old data (if any)
     while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //gather new data
 }
 

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -244,33 +244,6 @@ bool checkIfAdcWaitOver(void)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-void doCellDataGather(uint8_t * presentState)
-{ //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
-    //round-robin state handlers
-    static uint8_t chipAddress = FIRST_IC_ADDR;
-    static char cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
-
-    validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
-
-    //determine which LTC68042 IC & CVR to read next
-    cellVoltageRegister++;
-    if (cellVoltageRegister >= 'E')
-    {
-        //LTC6804 only has registers A,B,C,D
-        cellVoltageRegister = 'A'; //reset back to first CVR
-        if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
-        {
-            //last "LTC_STATE_GATHER" call for this cycle
-            //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
-            startCellConversion(); //start the next cell conversion //takes a while to finish
-            chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
-            *presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
-        }
-    }
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-
 //either gather next QTY3 cell voltages from LTC6804, or process a complete batch of returned cell voltage data.
 //raw cell voltages are stored in file-scoped "cellVoltages_counts[][]"" array
 //latest validated results are stored in a different, globally-accessible array inside "LTC68042_result.c"
@@ -283,41 +256,66 @@ void doCellDataGather(uint8_t * presentState)
 //
 // Note: if called too soon after a conversion is triggered, the state machine will return immediately, so more
 //   calls will be required until the wait time expires.
-// returns NO__GATHERING_CELL_DATA while gathering data, DONE__CELL_DATA_PROCESSED each time all data is processed
+// returns GATHERING_CELL_DATA while gathering data, CELL_DATA_PROCESSED each time all data is processed
 bool LTC68042cell_nextVoltages(void)
 {
     static uint8_t presentState = LTC_STATE_FIRSTRUN;
-    bool cellVoltageDataStatus = NO__GATHERING_CELL_DATA;
+    bool cellVoltageDataStatus = GATHERING_CELL_DATA;
 
     if (LTC68042configure_wakeup() == LTC6804_CORE_JUST_WOKE_UP) { presentState = LTC_STATE_FIRSTRUN; }
+
+    if (presentState == LTC_STATE_GATHER)
+    { //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
+
+        //round-robin state handlers
+        static uint8_t chipAddress = FIRST_IC_ADDR;
+        static char cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
+
+        validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
+
+        //determine which LTC68042 IC & CVR to read next
+        cellVoltageRegister++;
+        if (cellVoltageRegister >= 'E')
+        {
+            //LTC6804 only has registers A,B,C,D
+            cellVoltageRegister = 'A'; //reset back to first CVR
+
+            if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
+            {
+                //last "LTC_STATE_GATHER" call for this cycle
+                //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
+                startCellConversion(); //start the next cell conversion //takes a while to finish
+
+                chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
+                presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
+            }
+        }
+    }
 
     //for LTC_WAITING_FOR_ADC: if done waiting, fall through to GATHER
     //  don't gather data or advance the state if the current
     //  conversion is not complete (should not usually be necessary in key-on mode)
-    if (LTC_WAITING_FOR_ADC == presentState)
+    else if (LTC_WAITING_FOR_ADC == presentState)
     {
         if (true == checkIfAdcWaitOver())
         {
             //then wait is over
-            doCellDataGather(&presentState); // do first gather
-            presentState = LTC_STATE_GATHER;
+            presentState = LTC_STATE_GATHER; // do first gather
         }
         //else
             //presentState = LTC_WAITING_FOR_ADC; // hold in current state
     }
 
-    else if (LTC_STATE_GATHER == presentState) { doCellDataGather(&presentState); }
-
-    else if (LTC_STATE_PROCESS == presentState)
+    else if (presentState == LTC_STATE_PROCESS)
     {
         //all cell voltages read...
         processAllCellVoltages(); //do math and store in LTC68042_result.c
-        cellVoltageDataStatus = DONE__CELL_DATA_PROCESSED;
+        cellVoltageDataStatus = CELL_DATA_PROCESSED;
         presentState = LTC_WAITING_FOR_ADC; //wait if needed on next run (a trigger has already happened)
 
     }
 
-    else if (LTC_STATE_FIRSTRUN == presentState)
+    else if (presentState == LTC_STATE_FIRSTRUN)
     {
         //LTC6804 ICs were previously off
         LTC68042configure_programVolatileDefaults();
@@ -341,8 +339,8 @@ bool LTC68042cell_nextVoltages(void)
 //JTS2doNext: rewrite to remove double call hack
 void LTC68042cell_acquireAllCellVoltages(void)
 {
-    while (LTC68042cell_nextVoltages() != DONE__CELL_DATA_PROCESSED) { ; } //clear old data (if any)
-    while (LTC68042cell_nextVoltages() != DONE__CELL_DATA_PROCESSED) { ; } //gather new data
+    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //clear old data (if any)
+    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //gather new data
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -11,7 +11,7 @@
 //  Example: cellVoltages_counts[0][ 1] is IC_1 cell_02
 //  Example: cellVoltages_counts[3][11] is IC_4 cell_12
 uint16_t cellVoltages_counts[TOTAL_IC][CELLS_PER_IC];
-uint32_t conversionStart_ms = 0;
+uint32_t conversionStart_us = 0;
 
 //JTS2doLater: Add cell voltage test that sets user alert if a cell voltage suddenly changes from 'balanced' to 'majorly imbalanced'
 
@@ -37,7 +37,7 @@ void startCellConversion(void)
     cmd[3] = (uint8_t)(temp_pec);
 
     LTC68042configure_spiWrite(4,cmd); //send 'adcv' command to all LTC6804s (broadcast command)
-    conversionStart_ms = millis();
+    conversionStart_us = micros();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -236,73 +236,93 @@ void processAllCellVoltages(void)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+bool checkIfAdcWaitOver(void)
+{
+    if ((LTC6804_MAX_CONVERSION_TIME_ms * 1000) < (micros() - conversionStart_us)) { return true;  }
+    else                                                                           { return false; }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+void doCellDataGather(uint8_t * presentState)
+{ //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
+    //round-robin state handlers
+    static uint8_t chipAddress = FIRST_IC_ADDR;
+    static char cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
+
+    validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
+
+    //determine which LTC68042 IC & CVR to read next
+    cellVoltageRegister++;
+    if (cellVoltageRegister >= 'E')
+    {
+        //LTC6804 only has registers A,B,C,D
+        cellVoltageRegister = 'A'; //reset back to first CVR
+        if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
+        {
+            //last "LTC_STATE_GATHER" call for this cycle
+            //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
+            startCellConversion(); //start the next cell conversion //takes a while to finish
+            chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
+            *presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
 //either gather next QTY3 cell voltages from LTC6804, or process a complete batch of returned cell voltage data.
 //raw cell voltages are stored in file-scoped "cellVoltages_counts[][]"" array
 //latest validated results are stored in a different, globally-accessible array inside "LTC68042_result.c"
 //Example with QTY48 cells:
 //  -the absolute first call starts a conversion.
-//  After that, the behavior is as follows:
+//  After that, the behavior is as follows (see note):
 //  -the next sixteen calls ( (48 cells) / (3 cells per call) = 16 calls ) read back QTY48 cell voltages.
-//  -The seventeenth call performs all pack voltage math and stores valid results in LTC68042_result.c
+//    (the last "read back" call also starts another conversion)
+//  -the seventeenth call performs all pack voltage math and stores valid results in LTC68042_result.c
 //
-//returns false while gathering data, true each time all data is processed
+// Note: if called too soon after a conversion is triggered, the state machine will return immediately, so more
+//   calls will be required until the wait time expires.
+// returns NO__GATHERING_CELL_DATA while gathering data, DONE__CELL_DATA_PROCESSED each time all data is processed
 bool LTC68042cell_nextVoltages(void)
 {
     static uint8_t presentState = LTC_STATE_FIRSTRUN;
-    static bool conversionInProcess = false; //used to speed up execution of conversion complete test
-    bool cellVoltageDataStatus = GATHERING_CELL_DATA;
+    bool cellVoltageDataStatus = NO__GATHERING_CELL_DATA;
 
     if (LTC68042configure_wakeup() == LTC6804_CORE_JUST_WOKE_UP) { presentState = LTC_STATE_FIRSTRUN; }
 
-    if (presentState == LTC_STATE_GATHER)
-    { //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
-        // but don't gather data or advance the state if the  current conversion is not complete (should not usually be necessary)
-        if ( ( ! conversionInProcess) || (LTC6804_MAX_CONVERSION_TIME_ms < (millis() - conversionStart_ms)) )
+    //for LTC_WAITING_FOR_ADC: if done waiting, fall through to GATHER
+    //  don't gather data or advance the state if the current
+    //  conversion is not complete (should not usually be necessary in key-on mode)
+    if (LTC_WAITING_FOR_ADC == presentState)
+    {
+        if (true == checkIfAdcWaitOver())
         {
-            //then no conversion is in process or it has completed
-            conversionInProcess = false;
-
-            //round-robin state handlers
-            static uint8_t chipAddress = FIRST_IC_ADDR;
-            static char cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
-
-            validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
-
-            //determine which LTC68042 IC & CVR to read next
-            cellVoltageRegister++;
-            if (cellVoltageRegister >= 'E')
-            {
-                //LTC6804 only has registers A,B,C,D
-                cellVoltageRegister = 'A'; //reset back to first CVR
-
-                if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
-                {
-                    //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
-                    startCellConversion(); //start the next cell conversion //takes a while to finish
-                    conversionInProcess = true;
-
-                    chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
-                    presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
-                }
-            }
+            //then wait is over
+            doCellDataGather(&presentState); // do first gather
+            presentState = LTC_STATE_GATHER;
         }
+        //else
+            //presentState = LTC_WAITING_FOR_ADC; // hold in current state
     }
 
-    else if (presentState == LTC_STATE_PROCESS)
+    else if (LTC_STATE_GATHER == presentState) { doCellDataGather(&presentState); }
+
+    else if (LTC_STATE_PROCESS == presentState)
     {
         //all cell voltages read...
         processAllCellVoltages(); //do math and store in LTC68042_result.c
-        cellVoltageDataStatus = CELL_DATA_PROCESSED;
-        presentState = LTC_STATE_GATHER; //gather data on next run
+        cellVoltageDataStatus = DONE__CELL_DATA_PROCESSED;
+        presentState = LTC_WAITING_FOR_ADC; //wait if needed on next run (a trigger has already happened)
+
     }
 
-    else if (presentState == LTC_STATE_FIRSTRUN)
+    else if (LTC_STATE_FIRSTRUN == presentState)
     {
         //LTC6804 ICs were previously off
         LTC68042configure_programVolatileDefaults();
         startCellConversion();
-        conversionInProcess = true;
-        presentState = LTC_STATE_GATHER;
+        presentState = LTC_WAITING_FOR_ADC;
     }
 
     else
@@ -321,8 +341,8 @@ bool LTC68042cell_nextVoltages(void)
 //JTS2doNext: rewrite to remove double call hack
 void LTC68042cell_acquireAllCellVoltages(void)
 {
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //clear old data (if any)
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //gather new data
+    while (LTC68042cell_nextVoltages() != DONE__CELL_DATA_PROCESSED) { ; } //clear old data (if any)
+    while (LTC68042cell_nextVoltages() != DONE__CELL_DATA_PROCESSED) { ; } //gather new data
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.h
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.h
@@ -10,8 +10,8 @@
     #define LTC_STATE_GATHER             2
     #define LTC_STATE_PROCESS            3
 
-    #define NO__GATHERING_CELL_DATA    0
-    #define DONE__CELL_DATA_PROCESSED  1
+    #define GATHERING_CELL_DATA  0
+    #define CELL_DATA_PROCESSED  1
 
     #define LTC6804_MAX_CONVERSION_TIME_ms 5 //4.43 ms in '2kHz' sampling mode
 

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.h
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.h
@@ -3,13 +3,15 @@
 
 #ifndef LTC68042cell_h
     #define LTC68042cell_h
-    
-    #define LTC_STATE_FIRSTRUN 0
-    #define LTC_STATE_GATHER   1
-    #define LTC_STATE_PROCESS  2
 
-    #define GATHERING_CELL_DATA 0
-    #define CELL_DATA_PROCESSED 1
+
+    #define LTC_STATE_FIRSTRUN           0
+    #define LTC_WAITING_FOR_ADC          1
+    #define LTC_STATE_GATHER             2
+    #define LTC_STATE_PROCESS            3
+
+    #define NO__GATHERING_CELL_DATA    0
+    #define DONE__CELL_DATA_PROCESSED  1
 
     #define LTC6804_MAX_CONVERSION_TIME_ms 5 //4.43 ms in '2kHz' sampling mode
 

--- a/Firmware/firmwareLiBCM/src/key.cpp
+++ b/Firmware/firmwareLiBCM/src/key.cpp
@@ -119,9 +119,8 @@ void keyOn_coldBootTasks(void)
     METSCI_enable();
     LED(3,ON);
 
-    //process cell voltages
-    while(millis() - timeSinceLTC6804conversionStarted_us < LTC6804_MAX_CONVERSION_TIME_ms) { ; } //wait for conversion to finish
-    while(LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //read all cell voltages back
+    //read and process cell voltages, waiting for conversion to finish if needed
+    while(LTC68042cell_nextVoltages() != DONE__CELL_DATA_PROCESSED) { ; } //read all cell voltages back
     vPackSpoof_setVoltage();
     SoC_setBatteryStateNow_percent(SoC_estimateFromRestingCellVoltage_percent());
     BATTSCI_enable(); //must occur after we have valid Vcell data

--- a/Firmware/firmwareLiBCM/src/key.cpp
+++ b/Firmware/firmwareLiBCM/src/key.cpp
@@ -111,7 +111,6 @@ void keyOn_coldBootTasks(void)
     gpio_turnPowerSensors_on();
     LTC68042configure_pulseChipSelectLow(SPECIFIED_MAX_WAKEUP_TIME_LTCCORE_MICROSECONDS); //wake LTC6804
     LTC68042cell_nextVoltages(); //first call starts LTC6804 conversion
-    uint32_t timeSinceLTC6804conversionStarted_us = millis();
 
     //other startup initialization tasks
     vPackSpoof_handleKeyON();
@@ -120,7 +119,7 @@ void keyOn_coldBootTasks(void)
     LED(3,ON);
 
     //read and process cell voltages, waiting for conversion to finish if needed
-    while(LTC68042cell_nextVoltages() != DONE__CELL_DATA_PROCESSED) { ; } //read all cell voltages back
+    while(LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //read all cell voltages back
     vPackSpoof_setVoltage();
     SoC_setBatteryStateNow_percent(SoC_estimateFromRestingCellVoltage_percent());
     BATTSCI_enable(); //must occur after we have valid Vcell data


### PR DESCRIPTION
Changed LTC68042cell_nextVoltages() to wait for acquisition to complete.

If LTC68042cell_nextVoltages() is called in GATHER state while an acquisition is in process, it now returns without gathering data and without advancing its internal state, avoiding gathering stale data. The new "WAITING_FOR_ADC" state will introduce an extra event loop iteration in key-on mode.  The next PR will optimize out this extra delay.
