### PR TITLE
Provide a non-pipelined cell data acquisition mode to optimize test (BIST) code. (aka FORCE_TRIGGER)

### DIFF
--- a/Firmware/firmwareLiBCM/firmwareLiBCM.ino
+++ b/Firmware/firmwareLiBCM/firmwareLiBCM.ino
@@ -4,7 +4,7 @@
 
 #include "src/libcm.h"
 
-void setup() 
+void setup()
 {
     //getting here takes ~02 milliseconds after poweron reset
     //getting here takes ~16 milliseconds after IMA switch on
@@ -23,7 +23,7 @@ void setup()
     if (gpio_keyStateNow() == GPIO_KEY_ON) { keyOn_coldBootTasks();          }
     else                                   { debugUSB_printWelcomeMessage(); }
 
-    bringupTester_gridcharger(); 
+    bringupTester_gridcharger();
     bringupTester_motherboard();
 
     wdt_enable(WDTO_2S); //set watchdog reset vector to 2 seconds
@@ -48,7 +48,7 @@ void loop()
     {
         if (eeprom_expirationStatus_get() != FIRMWARE_EXPIRED) { BATTSCI_sendFrames(); } //P1648 when firmware expired
 
-        LTC68042cell_nextVoltages(); //round-robin handler measures QTY3 cell voltages per call
+        LTC68042cell_nextVoltages(LTC_TRIGGERMODE_CONTINUOUS); //round-robin handler measures QTY3 cell voltages per call
         METSCI_processLatestFrame();
         adc_updateBatteryCurrent();
         vPackSpoof_setVoltage();

--- a/Firmware/firmwareLiBCM/firmwareLiBCM.ino
+++ b/Firmware/firmwareLiBCM/firmwareLiBCM.ino
@@ -48,7 +48,7 @@ void loop()
     {
         if (eeprom_expirationStatus_get() != FIRMWARE_EXPIRED) { BATTSCI_sendFrames(); } //P1648 when firmware expired
 
-        LTC68042cell_nextVoltages(LTC_TRIGGERMODE_CONTINUOUS); //round-robin handler measures QTY3 cell voltages per call
+        LTC68042cell_nextVoltages(LTC_TRIGGERMODE_ROUND_ROBIN); //round-robin handler measures QTY3 cell voltages per call
         METSCI_processLatestFrame();
         adc_updateBatteryCurrent();
         vPackSpoof_setVoltage();

--- a/Firmware/firmwareLiBCM/src/BringupTester.cpp
+++ b/Firmware/firmwareLiBCM/src/BringupTester.cpp
@@ -270,6 +270,7 @@ bool testDischargeFETs(void)
         delay(500); //wait for filter network to settle
 
         LTC68042cell_acquireAllCellVoltages();
+        LTC68042cell_acquireAllCellVoltages();
 
         for (uint8_t ii=0; ii<TOTAL_IC; ii++) { debugUSB_printOneICsCellVoltages( ii, 3); }
     }

--- a/Firmware/firmwareLiBCM/src/BringupTester.cpp
+++ b/Firmware/firmwareLiBCM/src/BringupTester.cpp
@@ -8,7 +8,7 @@
 //////////////////////////////////////////////////////////////////
 
 void serialUSB_waitForEmptyBuffer(void)
-{   
+{
     //send all buffered serial data before starting each test (in case of brownout/reset)
     while (Serial.availableForWrite() != 63) { ; } //do nothing
 }
@@ -42,7 +42,7 @@ void bringupTester_gridcharger(void)
 {
     #ifdef RUN_BRINGUP_TESTER_GRIDCHARGER
         while (1) //this function never returns
-        {       
+        {
             Serial.print(F("\nRunning Grid Charger Test: "));
             #ifdef GRIDCHARGER_IS_1500W
                 Serial.print(F("GRIDCHARGER_IS_1500W"));
@@ -204,7 +204,7 @@ bool testLTC6804isoSPI(void)
     delay(50);
 
     Serial.print(F("\nLTC6804 - VREF test: "));
-    if (LTC6804gpio_areAllVoltageReferencesPassing() == true) { Serial.print(F("\nresult: passed")); } 
+    if (LTC6804gpio_areAllVoltageReferencesPassing() == true) { Serial.print(F("\nresult: passed")); }
     else                                                      { Serial.print(F("\nresult: FAIL!! !! !! !!")); didTestFail = true; }
 
     for (int ii=0; ii<5; ii++) { LTC68042cell_acquireAllCellVoltages(); delay(10); } //generate isoSPI traffic to check for errors
@@ -266,17 +266,16 @@ bool testDischargeFETs(void)
         {
             LTC68042configure_setBalanceResistors(FIRST_IC_ADDR + ii, cellDischargeBitmaps[bitmapPattern], LTC6804_DISCHARGE_TIMEOUT_02_SECONDS);
         }
-            
+
         delay(500); //wait for filter network to settle
 
-        LTC68042cell_acquireAllCellVoltages();
         LTC68042cell_acquireAllCellVoltages();
 
         for (uint8_t ii=0; ii<TOTAL_IC; ii++) { debugUSB_printOneICsCellVoltages( ii, 3); }
     }
 
     return didTestFail;
-    
+
     //JTS2do: Automate test results.
     //right now you must paste the results into the following spreadsheet and verify everything is working properly:
     //~/Honda_Insight_LiBCM/Test Fixtures/LTC6804 Discharge Tester Analysis.ods
@@ -290,11 +289,11 @@ bool testLiDisplayLoopback(void)
 
     Serial.print(F("\nLiDisplay loopback test: "));
     serialUSB_waitForEmptyBuffer();
-        
+
     Serial1.begin(57600,SERIAL_8N1);
 
     while (Serial1.available() != 0) { Serial1.read(); } //empty buffer
-    
+
     for (char charToLoopback = 'A'; charToLoopback <= 'Z'; charToLoopback++)
     {
         Serial1.write(charToLoopback);

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -319,10 +319,8 @@ bool LTC68042cell_nextVoltages(void)
 
 //Only call when keyOFF //takes too long to execute when keyON (causes check engine light)
 //Results are stored in "LTC68042_results.c"
-//JTS2doNext: rewrite to remove double call hack
 void LTC68042cell_acquireAllCellVoltages(void)
 {
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //clear old data (if any)
     while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //gather new data
 }
 

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -13,8 +13,6 @@
 uint16_t cellVoltages_counts[TOTAL_IC][CELLS_PER_IC];
 uint8_t  chipAddress = FIRST_IC_ADDR;
 char     cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
-bool     conversionInProcess = false; //used to speed up execution of conversion complete test
-uint32_t conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
 uint32_t conversionStart_us = 0;
 
 //JTS2doLater: Add cell voltage test that sets user alert if a cell voltage suddenly changes from 'balanced' to 'majorly imbalanced'
@@ -22,7 +20,7 @@ uint32_t conversionStart_us = 0;
 /////////////////////////////////////////////////////////////////////////////////////////
 
 //tell all LTC68042 ICs to measure all cells
-void startCellConversion(void)
+void startCellConversionAndResetCellCounters(void)
 {
     uint8_t cmd[4];
 
@@ -43,10 +41,8 @@ void startCellConversion(void)
     LTC68042configure_spiWrite(4,cmd); //send 'adcv' command to all LTC6804s (broadcast command)
 
     conversionStart_us = micros();
-    conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
     chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
     cellVoltageRegister = 'A';
-    conversionInProcess = true;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -245,108 +241,139 @@ void processAllCellVoltages(void)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+bool checkIfAdcWaitOver(void)
+{
+   if ((LTC6804_MAX_CONVERSION_TIME_ms * 1000) < (micros() - conversionStart_us)) { return true;  }
+   else                                                                           { return false; }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+//for triggerMode LTC_TRIGGERMODE_ROUND_ROBIN or LTC_TRIGGERMODE_TRIGGERED,
 //either gather next QTY3 cell voltages from LTC6804, or process a complete batch of returned cell voltage data.
 //raw cell voltages are stored in file-scoped "cellVoltages_counts[][]"" array
 //latest validated results are stored in a different, globally-accessible array inside "LTC68042_result.c"
-//Example with QTY48 cells:
+//for triggerMode LTC_TRIGGERMODE_FORCE_TRIGGERED, abandons any existing conversion and moves to a "ready to trigger" state (see note)
+//  see LTC68042cell.h for more explanation
+//Example with QTY48 cells (except if triggerMode is LTC_TRIGGERMODE_FORCE_TRIGGERED):
 //  -the absolute first call starts a conversion.
-//  After that, the behavior is as follows:
+//  After that, the behavior is as follows (see note):
 //  -the next sixteen calls ( (48 cells) / (3 cells per call) = 16 calls ) read back QTY48 cell voltages.
-//  -The seventeenth call performs all pack voltage math and stores valid results in LTC68042_result.c
+//  -if triggerMode is LTC_TRIGGERMODE_ROUND_ROBIN, the last "read back" call also starts another conversion
+//  -the seventeenth call performs all pack voltage math and stores valid results in LTC68042_result.c
+//  -if triggerMode is LTC_TRIGGERMODE_TRIGGERED, an eighteenth call is required to start another conversion
 //
-//returns GATHERING_CELL_DATA while gathering data, CELL_DATA_PROCESSED each time all data is processed
+// Note: if called too soon after a conversion is triggered, the state machine will return immediately, so more
+//   calls will be required until the wait time expires.
+//if called with triggerMode LTC_TRIGGERMODE_ROUND_ROBIN or LTC_TRIGGERMODE_TRIGGERED,
+// returns NO__GATHERING_CELL_DATA while gathering data, DONE__CELL_DATA_PROCESSED each time all data is processed
+//if called with triggerMode LTC_TRIGGERMODE_FORCE_TRIGGERED,
+// returns DONE__READY_TO_TRIGGER if state machine is ready to trigger a conversion on the next call, else
+//   NO__WAITING_FOR_READY if a wait is required
 uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 {
     static uint8_t presentState = LTC_STATE_FIRSTRUN;
-    uint8_t cellVoltageDataStatus = GATHERING_CELL_DATA;
+    uint8_t cellVoltageDataStatus = NO__GATHERING_CELL_DATA;
 
     if (LTC68042configure_wakeup() == LTC6804_CORE_JUST_WOKE_UP) { presentState = LTC_STATE_FIRSTRUN; }
 
-    if ((presentState & LTC_STATE_TRIGGER) || (LTC_TRIGGERMODE_FORCE_TRIGGERED == triggerMode))
+    if (LTC_TRIGGERMODE_FORCE_TRIGGERED == triggerMode)
     {
-        if ( ( ! conversionInProcess) || (conversionExpectedDuration_us < (micros() - conversionStart_us)) )
+        // in almost all cases, we do:
+        presentState = LTC_STATE_TRIGGER;
+        cellVoltageDataStatus = DONE__READY_TO_TRIGGER;
+
+        // now handle exceptions:
+        if      (LTC_STATE_FIRSTRUN == presentState) { LTC68042configure_programVolatileDefaults(); }
+        else if (LTC_WAITING_FOR_ADC == presentState)
         {
-            //then no conversion is in process or last one has completed
-            startCellConversion();
-            presentState = LTC_STATE_GATHER;
+            if (false == checkIfAdcWaitOver())
+            {
+                // then we still need to wait
+                //presentState = LTC_WAITING_FOR_ADC; // stay in current state
+                cellVoltageDataStatus = NO__WAITING_FOR_READY;
+            }
         }
-        else
+        else if (LTC_STATE_PROCESS == presentState)
         {
-            //then we need to wait for it to complete before starting ours, so don't advance presentState, and
-            cellVoltageDataStatus = WAITING_TO_TRIGGER;
+            //then a conversion might be in process, so
+            presentState = LTC_WAITING_FOR_ADC;
+            cellVoltageDataStatus = NO__WAITING_FOR_READY;
         }
     }
 
-    else if (presentState & LTC_STATE_GATHER)
-    { //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
-        // but don't gather data or advance the state if the  current conversion is not complete (should not usually be necessary)
-        if ( ( ! conversionInProcess) || (conversionExpectedDuration_us < (micros() - conversionStart_us)) )
+    //for LTC_WAITING_FOR_ADC: don't gather data or advance the state if the current
+    //  conversion is not complete (should not usually be necessary in key-on mode)
+    else if ( ( (LTC_WAITING_FOR_ADC == presentState) && (true == checkIfAdcWaitOver()) ) ||
+              (LTC_STATE_GATHER == presentState)
+            )
+    {
+        //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
+        validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
+
+        //determine which LTC68042 IC & CVR to read next
+        cellVoltageRegister++;
+        if (cellVoltageRegister >= 'E')
         {
-            //then no conversion is in process or last one has completed
-            conversionInProcess = false;
-
-            validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
-
-            //determine which LTC68042 IC & CVR to read next
-            cellVoltageRegister++;
-            if (cellVoltageRegister >= 'E')
+            //LTC6804 only has registers A,B,C,D
+            cellVoltageRegister = 'A'; //reset back to first CVR
+            if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
             {
-                //LTC6804 only has registers A,B,C,D
-                cellVoltageRegister = 'A'; //reset back to first CVR
-                if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
+                //last "LTC_STATE_GATHER" call for this cycle
+                //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
+                if (LTC_TRIGGERMODE_ROUND_ROBIN == triggerMode)
                 {
-                    //last "LTC_STATE_GATHER" call for this cycle
-                    //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
-                    if (LTC_TRIGGERMODE_CONTINUOUS == triggerMode)
-                    {
-                        startCellConversion(); //start the next cell conversion //takes a while to finish
-                        presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
-                    }
-                    else if (LTC_TRIGGERMODE_TRIGGERED == triggerMode)
-                    {
-                        presentState = LTC_STATE_PROCESS_TRIGGERED; //all cell voltages gathered.  Process data on next run, but trigger after that
-                    }
-                    else
-                    {
-                        Serial.print(F("\nillegal LTC68042cell trigger mode"));
-                        while (1) {;} //hang here until watchdog resets.
-                    }
+                    startCellConversionAndResetCellCounters(); //start the next cell conversion //takes a while to finish
+                    presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
+                }
+                else if (LTC_TRIGGERMODE_TRIGGERED == triggerMode)
+                {
+                    presentState = LTC_STATE_PROCESS_TRIGGERED; //all cell voltages gathered.  Process data on next run, but trigger after that
+                }
+                else
+                {
+                    Serial.print(F("\nillegal LTC68042cell trigger mode"));
+                    while (1) {;} //hang here until watchdog resets.
                 }
             }
         }
     }
 
-    else if (presentState & (LTC_STATE_PROCESS | LTC_STATE_PROCESS_TRIGGERED))
+    else if ((LTC_STATE_PROCESS == presentState) || (LTC_STATE_PROCESS_TRIGGERED == presentState))
     {
         //all cell voltages read...
-        if ((presentState & LTC_STATE_PROCESS_TRIGGERED) && (LTC_TRIGGERMODE_CONTINUOUS == triggerMode))
+
+        //handle transision from LTC_STATE_PROCESS_TRIGGERED to LTC_TRIGGERMODE_ROUND_ROBIN
+        if ((LTC_STATE_PROCESS_TRIGGERED == presentState) && (LTC_TRIGGERMODE_ROUND_ROBIN == triggerMode))
         {
-            //then triggerMode changed from TRIGGERED to CONTINUOUS, allow the change of mode,
-            //  and start a conversion here to get a head start...
-            startCellConversion();
-            presentState = LTC_STATE_PROCESS; //for next state determination
-        }
-        else if ((presentState & LTC_STATE_PROCESS) && (LTC_STATE_PROCESS_TRIGGERED == triggerMode))
-        {
-            //then triggerMode changed from CONTINUOUS to TRIGGERED: an extraneous trigger has already happened,
-            //  but change to presentState = LTC_STATE_PROCESS_TRIGGERED, and wait at start of LTC_STATE_TRIGGER
-            //  might happen
-            presentState = LTC_STATE_PROCESS_TRIGGERED; //for next state determination
+            //then triggerMode changed from TRIGGERED to ROUND_ROBIN: allow the change of mode,
+            //  and start a belated conversion ...
+            startCellConversionAndResetCellCounters();
+            //we are now effectively back to ROUND_ROBIN, so this is needed for next state determination coming right up
+            presentState = LTC_STATE_PROCESS;
         }
 
         processAllCellVoltages(); //do math and store in LTC68042_result.c
-        cellVoltageDataStatus = CELL_DATA_PROCESSED;
+        cellVoltageDataStatus = DONE__CELL_DATA_PROCESSED;
 
-        if (presentState & LTC_STATE_PROCESS_TRIGGERED) { presentState = LTC_STATE_TRIGGER; } //trigger on next run
-        else                                            { presentState = LTC_STATE_GATHER;  } //gather data on next run (a trigger has already happened)
+        if (LTC_STATE_PROCESS_TRIGGERED == presentState) { presentState = LTC_STATE_TRIGGER;   } //trigger on next run
+        else                                             { presentState = LTC_WAITING_FOR_ADC; } //wait if needed on next run (a trigger has already happened)
     }
 
-    else if (presentState == LTC_STATE_FIRSTRUN)
+    else if (LTC_STATE_FIRSTRUN == presentState)
     {
         //LTC6804 ICs were previously off
         LTC68042configure_programVolatileDefaults();
-        startCellConversion();
-        presentState = LTC_STATE_GATHER;
+        startCellConversionAndResetCellCounters();
+        presentState = LTC_WAITING_FOR_ADC;
+    }
+
+    else if (LTC_STATE_TRIGGER == presentState)
+    {
+        //then trigger a conversion
+        //  Note: by design, can't get to this state while a conversion is in process, so no check is performent
+        startCellConversionAndResetCellCounters();
+        presentState = LTC_WAITING_FOR_ADC;
     }
 
     else
@@ -364,8 +391,8 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 //Results are stored in "LTC68042_results.c"
 void LTC68042cell_acquireAllCellVoltages(void)
 {
-    while (LTC68042cell_nextVoltages(LTC_TRIGGERMODE_FORCE_TRIGGERED) == WAITING_TO_TRIGGER) { ; } //abandon any in-process acquisition (waiting for it to complete, if needed)
-    while (LTC68042cell_nextVoltages(LTC_TRIGGERMODE_TRIGGERED) != CELL_DATA_PROCESSED) { ; } //gather new data
+    while (LTC68042cell_nextVoltages(LTC_TRIGGERMODE_FORCE_TRIGGERED) != DONE__READY_TO_TRIGGER)    { ; } //abandon any in-process acquisition (waiting for it to complete, if needed)
+    while (LTC68042cell_nextVoltages(LTC_TRIGGERMODE_TRIGGERED)       != DONE__CELL_DATA_PROCESSED) { ; } //gather new data
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -11,7 +11,7 @@
 //  Example: cellVoltages_counts[0][ 1] is IC_1 cell_02
 //  Example: cellVoltages_counts[3][11] is IC_4 cell_12
 uint16_t cellVoltages_counts[TOTAL_IC][CELLS_PER_IC];
-uint32_t conversionStart_ms = 0;
+uint32_t conversionStart_us = 0;
 
 //JTS2doLater: Add cell voltage test that sets user alert if a cell voltage suddenly changes from 'balanced' to 'majorly imbalanced'
 
@@ -37,7 +37,7 @@ void startCellConversion(void)
     cmd[3] = (uint8_t)(temp_pec);
 
     LTC68042configure_spiWrite(4,cmd); //send 'adcv' command to all LTC6804s (broadcast command)
-    conversionStart_ms = millis();
+    conversionStart_us = micros();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -236,73 +236,93 @@ void processAllCellVoltages(void)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+bool checkIfAdcWaitOver(void)
+{
+    if ((LTC6804_MAX_CONVERSION_TIME_ms * 1000) < (micros() - conversionStart_us)) { return true;  }
+    else                                                                           { return false; }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+void doCellDataGather(uint8_t * presentState)
+{ //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
+    //round-robin state handlers
+    static uint8_t chipAddress = FIRST_IC_ADDR;
+    static char cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
+
+    validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
+
+    //determine which LTC68042 IC & CVR to read next
+    cellVoltageRegister++;
+    if (cellVoltageRegister >= 'E')
+    {
+        //LTC6804 only has registers A,B,C,D
+        cellVoltageRegister = 'A'; //reset back to first CVR
+        if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
+        {
+            //last "LTC_STATE_GATHER" call for this cycle
+            //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
+            startCellConversion(); //start the next cell conversion //takes a while to finish
+            chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
+            *presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
 //either gather next QTY3 cell voltages from LTC6804, or process a complete batch of returned cell voltage data.
 //raw cell voltages are stored in file-scoped "cellVoltages_counts[][]"" array
 //latest validated results are stored in a different, globally-accessible array inside "LTC68042_result.c"
 //Example with QTY48 cells:
 //  -the absolute first call starts a conversion.
-//  After that, the behavior is as follows:
+//  After that, the behavior is as follows (see note):
 //  -the next sixteen calls ( (48 cells) / (3 cells per call) = 16 calls ) read back QTY48 cell voltages.
-//  -The seventeenth call performs all pack voltage math and stores valid results in LTC68042_result.c
+//    (the last "read back" call also starts another conversion)
+//  -the seventeenth call performs all pack voltage math and stores valid results in LTC68042_result.c
 //
-//returns false while gathering data, true each time all data is processed
+// Note: if called too soon after a conversion is triggered, the state machine will return immediately, so more
+//   calls will be required until the wait time expires.
+// returns NO__GATHERING_CELL_DATA while gathering data, DONE__CELL_DATA_PROCESSED each time all data is processed
 bool LTC68042cell_nextVoltages(void)
 {
     static uint8_t presentState = LTC_STATE_FIRSTRUN;
-    static bool conversionInProcess = false; //used to speed up execution of conversion complete test
-    bool cellVoltageDataStatus = GATHERING_CELL_DATA;
+    bool cellVoltageDataStatus = NO__GATHERING_CELL_DATA;
 
     if (LTC68042configure_wakeup() == LTC6804_CORE_JUST_WOKE_UP) { presentState = LTC_STATE_FIRSTRUN; }
 
-    if (presentState == LTC_STATE_GATHER)
-    { //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
-        // but don't gather data or advance the state if the  current conversion is not complete (should not usually be necessary)
-        if ( ( ! conversionInProcess) || (LTC6804_MAX_CONVERSION_TIME_ms < (millis() - conversionStart_ms)) )
+    //for LTC_WAITING_FOR_ADC: if done waiting, fall through to GATHER
+    //  don't gather data or advance the state if the current
+    //  conversion is not complete (should not usually be necessary in key-on mode)
+    if (LTC_WAITING_FOR_ADC == presentState)
+    {
+        if (true == checkIfAdcWaitOver())
         {
-            //then no conversion is in process or it has completed
-            conversionInProcess = false;
-
-            //round-robin state handlers
-            static uint8_t chipAddress = FIRST_IC_ADDR;
-            static char cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
-
-            validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
-
-            //determine which LTC68042 IC & CVR to read next
-            cellVoltageRegister++;
-            if (cellVoltageRegister >= 'E')
-            {
-                //LTC6804 only has registers A,B,C,D
-                cellVoltageRegister = 'A'; //reset back to first CVR
-
-                if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
-                {
-                    //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
-                    startCellConversion(); //start the next cell conversion //takes a while to finish
-                    conversionInProcess = true;
-
-                    chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
-                    presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
-                }
-            }
+            //then wait is over
+            doCellDataGather(&presentState); // do first gather
+            presentState = LTC_STATE_GATHER;
         }
+        //else
+            //presentState = LTC_WAITING_FOR_ADC; // hold in current state
     }
 
-    else if (presentState == LTC_STATE_PROCESS)
+    else if (LTC_STATE_GATHER == presentState) { doCellDataGather(&presentState); }
+
+    else if (LTC_STATE_PROCESS == presentState)
     {
         //all cell voltages read...
         processAllCellVoltages(); //do math and store in LTC68042_result.c
-        cellVoltageDataStatus = CELL_DATA_PROCESSED;
-        presentState = LTC_STATE_GATHER; //gather data on next run
+        cellVoltageDataStatus = DONE__CELL_DATA_PROCESSED;
+        presentState = LTC_WAITING_FOR_ADC; //wait if needed on next run (a trigger has already happened)
+
     }
 
-    else if (presentState == LTC_STATE_FIRSTRUN)
+    else if (LTC_STATE_FIRSTRUN == presentState)
     {
         //LTC6804 ICs were previously off
         LTC68042configure_programVolatileDefaults();
         startCellConversion();
-        conversionInProcess = true;
-        presentState = LTC_STATE_GATHER;
+        presentState = LTC_WAITING_FOR_ADC;
     }
 
     else
@@ -321,8 +341,8 @@ bool LTC68042cell_nextVoltages(void)
 //JTS2doNext: rewrite to remove double call hack
 void LTC68042cell_acquireAllCellVoltages(void)
 {
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //clear old data (if any)
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //gather new data
+    while (LTC68042cell_nextVoltages() != DONE__CELL_DATA_PROCESSED) { ; } //clear old data (if any)
+    while (LTC68042cell_nextVoltages() != DONE__CELL_DATA_PROCESSED) { ; } //gather new data
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -244,11 +244,12 @@ bool checkIfAdcWaitOver(void)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-void doCellDataGather(uint8_t * presentState)
+uint8_t doCellDataGather(void)
 { //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
     //round-robin state handlers
     static uint8_t chipAddress = FIRST_IC_ADDR;
     static char cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
+    uint8_t nextPresentState = LTC_STATE_GATHER; // default to remaining in gather state
 
     validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
 
@@ -264,9 +265,10 @@ void doCellDataGather(uint8_t * presentState)
             //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
             startCellConversion(); //start the next cell conversion //takes a while to finish
             chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
-            *presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
+            nextPresentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
         }
     }
+    return nextPresentState;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -299,14 +301,13 @@ bool LTC68042cell_nextVoltages(void)
         if (true == checkIfAdcWaitOver())
         {
             //then wait is over
-            doCellDataGather(&presentState); // do first gather
-            presentState = LTC_STATE_GATHER;
+            presentState = doCellDataGather(); // do first gather
         }
         //else
             //presentState = LTC_WAITING_FOR_ADC; // hold in current state
     }
 
-    else if (LTC_STATE_GATHER == presentState) { doCellDataGather(&presentState); }
+    else if (LTC_STATE_GATHER == presentState) { presentState = doCellDataGather(); }
 
     else if (LTC_STATE_PROCESS == presentState)
     {

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -243,8 +243,43 @@ void processAllCellVoltages(void)
 
 bool checkIfAdcWaitOver(void)
 {
-   if ((LTC6804_MAX_CONVERSION_TIME_ms * 1000) < (micros() - conversionStart_us)) { return true;  }
-   else                                                                           { return false; }
+    if ((LTC6804_MAX_CONVERSION_TIME_ms * 1000) < (micros() - conversionStart_us)) { return true;  }
+    else                                                                           { return false; }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+void doCellDataGather(uint8_t triggerMode, uint8_t * presentState)
+{
+    //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
+    validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
+
+    //determine which LTC68042 IC & CVR to read next
+    cellVoltageRegister++;
+    if (cellVoltageRegister >= 'E')
+    {
+        //LTC6804 only has registers A,B,C,D
+        cellVoltageRegister = 'A'; //reset back to first CVR
+        if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
+        {
+            //last "LTC_STATE_GATHER" call for this cycle
+            //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
+            if (LTC_TRIGGERMODE_ROUND_ROBIN == triggerMode)
+            {
+                startCellConversionAndResetCellCounters(); //start the next cell conversion //takes a while to finish
+                *presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
+            }
+            else if (LTC_TRIGGERMODE_TRIGGERED == triggerMode)
+            {
+                *presentState = LTC_STATE_PROCESS_TRIGGERED; //all cell voltages gathered.  Process data on next run, but trigger after that
+            }
+            else
+            {
+                Serial.print(F("\nillegal LTC68042cell trigger mode"));
+                while (1) {;} //hang here until watchdog resets.
+            }
+        }
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -279,15 +314,21 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 
     if (LTC_TRIGGERMODE_FORCE_TRIGGERED == triggerMode)
     {
-        // in almost all cases, we do:
-        presentState = LTC_STATE_TRIGGER;
-        cellVoltageDataStatus = DONE__READY_TO_TRIGGER;
-
-        // now handle exceptions:
-        if      (LTC_STATE_FIRSTRUN == presentState) { LTC68042configure_programVolatileDefaults(); }
+        if      (LTC_STATE_FIRSTRUN == presentState)
+        {
+            LTC68042configure_programVolatileDefaults();
+            presentState = LTC_STATE_TRIGGER;
+            cellVoltageDataStatus = DONE__READY_TO_TRIGGER;
+        }
         else if (LTC_WAITING_FOR_ADC == presentState)
         {
-            if (false == checkIfAdcWaitOver())
+            if (true == checkIfAdcWaitOver())
+            {
+                //then wait is over
+                presentState = LTC_STATE_TRIGGER;
+                cellVoltageDataStatus = DONE__READY_TO_TRIGGER;
+            }
+            else
             {
                 // then we still need to wait
                 //presentState = LTC_WAITING_FOR_ADC; // stay in current state
@@ -300,44 +341,29 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
             presentState = LTC_WAITING_FOR_ADC;
             cellVoltageDataStatus = NO__WAITING_FOR_READY;
         }
-    }
-
-    //for LTC_WAITING_FOR_ADC: don't gather data or advance the state if the current
-    //  conversion is not complete (should not usually be necessary in key-on mode)
-    else if ( ( (LTC_WAITING_FOR_ADC == presentState) && (true == checkIfAdcWaitOver()) ) ||
-              (LTC_STATE_GATHER == presentState)
-            )
-    {
-        //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
-        validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
-
-        //determine which LTC68042 IC & CVR to read next
-        cellVoltageRegister++;
-        if (cellVoltageRegister >= 'E')
+        else
         {
-            //LTC6804 only has registers A,B,C,D
-            cellVoltageRegister = 'A'; //reset back to first CVR
-            if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
-            {
-                //last "LTC_STATE_GATHER" call for this cycle
-                //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
-                if (LTC_TRIGGERMODE_ROUND_ROBIN == triggerMode)
-                {
-                    startCellConversionAndResetCellCounters(); //start the next cell conversion //takes a while to finish
-                    presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
-                }
-                else if (LTC_TRIGGERMODE_TRIGGERED == triggerMode)
-                {
-                    presentState = LTC_STATE_PROCESS_TRIGGERED; //all cell voltages gathered.  Process data on next run, but trigger after that
-                }
-                else
-                {
-                    Serial.print(F("\nillegal LTC68042cell trigger mode"));
-                    while (1) {;} //hang here until watchdog resets.
-                }
-            }
+            // in all other cases, we do:
+            presentState = LTC_STATE_TRIGGER;
+            cellVoltageDataStatus = DONE__READY_TO_TRIGGER;
         }
     }
+
+    //for LTC_WAITING_FOR_ADC: if done waiting, fall through to GATHERdon't gather data or advance the state if the current
+    //  conversion is not complete (should not usually be necessary in key-on mode)
+    else if (LTC_WAITING_FOR_ADC == presentState)
+    {
+        if (true == checkIfAdcWaitOver())
+        {
+            //then wait is over
+            doCellDataGather(triggerMode, &presentState); // do first gather
+            presentState = LTC_STATE_GATHER;
+        }
+        //else
+            //presentState = LTC_WAITING_FOR_ADC; // hold in current state
+    }
+
+    else if (LTC_STATE_GATHER == presentState) { doCellDataGather(triggerMode, &presentState); }
 
     else if ((LTC_STATE_PROCESS == presentState) || (LTC_STATE_PROCESS_TRIGGERED == presentState))
     {
@@ -358,6 +384,7 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 
         if (LTC_STATE_PROCESS_TRIGGERED == presentState) { presentState = LTC_STATE_TRIGGER;   } //trigger on next run
         else                                             { presentState = LTC_WAITING_FOR_ADC; } //wait if needed on next run (a trigger has already happened)
+
     }
 
     else if (LTC_STATE_FIRSTRUN == presentState)

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -11,6 +11,9 @@
 //  Example: cellVoltages_counts[0][ 1] is IC_1 cell_02
 //  Example: cellVoltages_counts[3][11] is IC_4 cell_12
 uint16_t cellVoltages_counts[TOTAL_IC][CELLS_PER_IC];
+uint8_t  chipAddress = FIRST_IC_ADDR;
+char     cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
+bool     conversionInProcess = false; //used to speed up execution of conversion complete test
 uint32_t conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
 uint32_t conversionStart_us = 0;
 
@@ -39,8 +42,11 @@ void startCellConversion(void)
 
     LTC68042configure_spiWrite(4,cmd); //send 'adcv' command to all LTC6804s (broadcast command)
 
-    conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
     conversionStart_us = micros();
+    conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
+    chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
+    cellVoltageRegister = 'A';
+    conversionInProcess = true;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -252,7 +258,6 @@ void processAllCellVoltages(void)
 uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 {
     static uint8_t presentState = LTC_STATE_FIRSTRUN;
-    static bool conversionInProcess = false; //used to speed up execution of conversion complete test
     uint8_t cellVoltageDataStatus = GATHERING_CELL_DATA;
 
     if (LTC68042configure_wakeup() == LTC6804_CORE_JUST_WOKE_UP) { presentState = LTC_STATE_FIRSTRUN; }
@@ -263,7 +268,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
         {
             //then no conversion is in process or last one has completed
             startCellConversion();
-            conversionInProcess = true;
             presentState = LTC_STATE_GATHER;
         }
         else
@@ -281,10 +285,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
             //then no conversion is in process or last one has completed
             conversionInProcess = false;
 
-            //round-robin state handlers
-            static uint8_t chipAddress = FIRST_IC_ADDR;
-            static char cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
-
             validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
 
             //determine which LTC68042 IC & CVR to read next
@@ -300,7 +300,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
                     if (LTC_TRIGGERMODE_CONTINUOUS == triggerMode)
                     {
                         startCellConversion(); //start the next cell conversion //takes a while to finish
-                        conversionInProcess = true;
                         presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
                     }
                     else if (LTC_TRIGGERMODE_TRIGGERED == triggerMode)
@@ -312,8 +311,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
                         Serial.print(F("\nillegal LTC68042cell trigger mode"));
                         while (1) {;} //hang here until watchdog resets.
                     }
-
-                    chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
                 }
             }
         }
@@ -327,7 +324,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
             //then triggerMode changed from TRIGGERED to CONTINUOUS, allow the change of mode,
             //  and start a conversion here to get a head start...
             startCellConversion();
-            conversionInProcess = true;
             presentState = LTC_STATE_PROCESS; //for next state determination
         }
         else if ((presentState & LTC_STATE_PROCESS) && (LTC_STATE_PROCESS_TRIGGERED == triggerMode))
@@ -350,7 +346,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
         //LTC6804 ICs were previously off
         LTC68042configure_programVolatileDefaults();
         startCellConversion();
-        conversionInProcess = true;
         presentState = LTC_STATE_GATHER;
     }
 

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -11,7 +11,8 @@
 //  Example: cellVoltages_counts[0][ 1] is IC_1 cell_02
 //  Example: cellVoltages_counts[3][11] is IC_4 cell_12
 uint16_t cellVoltages_counts[TOTAL_IC][CELLS_PER_IC];
-uint32_t conversionStart_ms = 0;
+uint32_t conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
+uint32_t conversionStart_us = 0;
 
 //JTS2doLater: Add cell voltage test that sets user alert if a cell voltage suddenly changes from 'balanced' to 'majorly imbalanced'
 
@@ -37,7 +38,9 @@ void startCellConversion(void)
     cmd[3] = (uint8_t)(temp_pec);
 
     LTC68042configure_spiWrite(4,cmd); //send 'adcv' command to all LTC6804s (broadcast command)
-    conversionStart_ms = millis();
+
+    conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
+    conversionStart_us = micros();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -245,21 +248,37 @@ void processAllCellVoltages(void)
 //  -the next sixteen calls ( (48 cells) / (3 cells per call) = 16 calls ) read back QTY48 cell voltages.
 //  -The seventeenth call performs all pack voltage math and stores valid results in LTC68042_result.c
 //
-//returns false while gathering data, true each time all data is processed
-bool LTC68042cell_nextVoltages(void)
+//returns GATHERING_CELL_DATA while gathering data, CELL_DATA_PROCESSED each time all data is processed
+uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 {
     static uint8_t presentState = LTC_STATE_FIRSTRUN;
     static bool conversionInProcess = false; //used to speed up execution of conversion complete test
-    bool cellVoltageDataStatus = GATHERING_CELL_DATA;
+    uint8_t cellVoltageDataStatus = GATHERING_CELL_DATA;
 
     if (LTC68042configure_wakeup() == LTC6804_CORE_JUST_WOKE_UP) { presentState = LTC_STATE_FIRSTRUN; }
 
-    if (presentState == LTC_STATE_GATHER)
+    if ((presentState & LTC_STATE_TRIGGER) || (LTC_TRIGGERMODE_FORCE_TRIGGERED == triggerMode))
+    {
+        if ( ( ! conversionInProcess) || (conversionExpectedDuration_us < (micros() - conversionStart_us)) )
+        {
+            //then no conversion is in process or last one has completed
+            startCellConversion();
+            conversionInProcess = true;
+            presentState = LTC_STATE_GATHER;
+        }
+        else
+        {
+            //then we need to wait for it to complete before starting ours, so don't advance presentState, and
+            cellVoltageDataStatus = WAITING_TO_TRIGGER;
+        }
+    }
+
+    else if (presentState & LTC_STATE_GATHER)
     { //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
         // but don't gather data or advance the state if the  current conversion is not complete (should not usually be necessary)
-        if ( ( ! conversionInProcess) || (LTC6804_MAX_CONVERSION_TIME_ms < (millis() - conversionStart_ms)) )
+        if ( ( ! conversionInProcess) || (conversionExpectedDuration_us < (micros() - conversionStart_us)) )
         {
-            //then no conversion is in process or it has completed
+            //then no conversion is in process or last one has completed
             conversionInProcess = false;
 
             //round-robin state handlers
@@ -274,26 +293,56 @@ bool LTC68042cell_nextVoltages(void)
             {
                 //LTC6804 only has registers A,B,C,D
                 cellVoltageRegister = 'A'; //reset back to first CVR
-
                 if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
                 {
+                    //last "LTC_STATE_GATHER" call for this cycle
                     //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
-                    startCellConversion(); //start the next cell conversion //takes a while to finish
-                    conversionInProcess = true;
+                    if (LTC_TRIGGERMODE_CONTINUOUS == triggerMode)
+                    {
+                        startCellConversion(); //start the next cell conversion //takes a while to finish
+                        conversionInProcess = true;
+                        presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
+                    }
+                    else if (LTC_TRIGGERMODE_TRIGGERED == triggerMode)
+                    {
+                        presentState = LTC_STATE_PROCESS_TRIGGERED; //all cell voltages gathered.  Process data on next run, but trigger after that
+                    }
+                    else
+                    {
+                        Serial.print(F("\nillegal LTC68042cell trigger mode"));
+                        while (1) {;} //hang here until watchdog resets.
+                    }
 
                     chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
-                    presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
                 }
             }
         }
     }
 
-    else if (presentState == LTC_STATE_PROCESS)
+    else if (presentState & (LTC_STATE_PROCESS | LTC_STATE_PROCESS_TRIGGERED))
     {
         //all cell voltages read...
+        if ((presentState & LTC_STATE_PROCESS_TRIGGERED) && (LTC_TRIGGERMODE_CONTINUOUS == triggerMode))
+        {
+            //then triggerMode changed from TRIGGERED to CONTINUOUS, allow the change of mode,
+            //  and start a conversion here to get a head start...
+            startCellConversion();
+            conversionInProcess = true;
+            presentState = LTC_STATE_PROCESS; //for next state determination
+        }
+        else if ((presentState & LTC_STATE_PROCESS) && (LTC_STATE_PROCESS_TRIGGERED == triggerMode))
+        {
+            //then triggerMode changed from CONTINUOUS to TRIGGERED: an extraneous trigger has already happened,
+            //  but change to presentState = LTC_STATE_PROCESS_TRIGGERED, and wait at start of LTC_STATE_TRIGGER
+            //  might happen
+            presentState = LTC_STATE_PROCESS_TRIGGERED; //for next state determination
+        }
+
         processAllCellVoltages(); //do math and store in LTC68042_result.c
         cellVoltageDataStatus = CELL_DATA_PROCESSED;
-        presentState = LTC_STATE_GATHER; //gather data on next run
+
+        if (presentState & LTC_STATE_PROCESS_TRIGGERED) { presentState = LTC_STATE_TRIGGER; } //trigger on next run
+        else                                            { presentState = LTC_STATE_GATHER;  } //gather data on next run (a trigger has already happened)
     }
 
     else if (presentState == LTC_STATE_FIRSTRUN)
@@ -318,11 +367,10 @@ bool LTC68042cell_nextVoltages(void)
 
 //Only call when keyOFF //takes too long to execute when keyON (causes check engine light)
 //Results are stored in "LTC68042_results.c"
-//JTS2doNext: rewrite to remove double call hack
 void LTC68042cell_acquireAllCellVoltages(void)
 {
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //clear old data (if any)
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //gather new data
+    while (LTC68042cell_nextVoltages(LTC_TRIGGERMODE_FORCE_TRIGGERED) == WAITING_TO_TRIGGER) { ; } //abandon any in-process acquisition (waiting for it to complete, if needed)
+    while (LTC68042cell_nextVoltages(LTC_TRIGGERMODE_TRIGGERED) != CELL_DATA_PROCESSED) { ; } //gather new data
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.h
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.h
@@ -3,13 +3,15 @@
 
 #ifndef LTC68042cell_h
     #define LTC68042cell_h
-    
-    #define LTC_STATE_FIRSTRUN 0
-    #define LTC_STATE_GATHER   1
-    #define LTC_STATE_PROCESS  2
 
-    #define GATHERING_CELL_DATA 0
-    #define CELL_DATA_PROCESSED 1
+
+    #define LTC_STATE_FIRSTRUN           0
+    #define LTC_WAITING_FOR_ADC          1
+    #define LTC_STATE_GATHER             2
+    #define LTC_STATE_PROCESS            3
+
+    #define NO__GATHERING_CELL_DATA    0
+    #define DONE__CELL_DATA_PROCESSED  1
 
     #define LTC6804_MAX_CONVERSION_TIME_ms 5 //4.43 ms in '2kHz' sampling mode
 

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.h
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.h
@@ -38,7 +38,7 @@
     #define NO__GATHERING_CELL_DATA    0
     #define DONE__CELL_DATA_PROCESSED  1
     #define NO__WAITING_FOR_READY      2
-    #define DONE__READY_TO_TRIGGER     2
+    #define DONE__READY_TO_TRIGGER     3
 
     #define LTC6804_MAX_CONVERSION_TIME_ms 5 //4.43 ms in '2kHz' sampling mode
 

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.h
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.h
@@ -5,38 +5,40 @@
     #define LTC68042cell_h
 
     // trigger mode argument values to LTC68042cell_nextVoltages()
-    //  CONTINUOUS: trigger another acqusition as soon as possible
-    //    This mode piplines the acquisitions, so that the next acquisition can occur
+    //  ROUND_ROBIN: trigger another acquisition as soon as possible
+    //    This mode pipelines the acquisitions, so that the next acquisition can occur
     //    (in the BMS ic's) while the data from the current one is being processed.
-    //    60 cells require 21 calls (at apropriate intervels) to LTC68042cell_nextVoltages()
+    //    60 cells require 21 calls (at appropriate intervals) to LTC68042cell_nextVoltages()
     //    for a complete acquisition cycle.
-    //  TRIGGERED: trigger an acqusition only at the next call after CELL_DATA_PROCESSED
-    //    This mode allows a acquisition to be syncronized with events outside of
-    //    LTC68042cell_nextVoltages(), and is optimum for testing cell votage changes
+    //  TRIGGERED: trigger an acquisition only at the next call after DONE__CELL_DATA_PROCESSED
+    //    This mode allows an acquisition to be synchronized with events outside of
+    //    LTC68042cell_nextVoltages(), and is optimum for testing cell voltage changes
     //    in response to specific events. This adds 1 extra call for a complete cycle.
-    //  FORCE_TRIGGERED: trigger an acqusition NOW, abandoning any previous acqusition
-    //    that is in process. This is optimum as the first, single, call when when
-    //    switching from CONTINUOUS to TRIGGERED to get a new acquisition without having
-    //    to take the time to complete a full call cycle on the current acquisition.
-    // NOTE: It is only appripriate to make a call with LTC_TRIGGERMODE_FORCE_TRIGGERED one
-    //       time, to start a new acquisition cycle. Following calls should be with
-    //       LTC_TRIGGERMODE_TRIGGERED until LTC68042cell_nextVoltages() returns CELL_DATA_PROCESSED.
+    //  FORCE_TRIGGERED: transition to "ready to trigger" ASAP, abandoning any previous acqusition
+    //    that is in process. This is optimum when switching from ROUND_ROBIN to TRIGGERED to get
+    //    ready for a new acquisition without having to take the time to complete a full call cycle
+    //    on the current acquisition.
+    // NOTE: If an acquisition is in process when LTC_TRIGGERMODE_FORCE_TRIGGERED is used, it will
+    //       return NO__WAITING_FOR_READY, so keep calling until it returns DONE__READY_TO_TRIGGER,
+    //       indicating all is ready to start a new acquisition cycle. Following calls should be with
+    //       LTC_TRIGGERMODE_TRIGGERED until LTC68042cell_nextVoltages() returns DONE__CELL_DATA_PROCESSED.
     // Switching between modes at any time is supported.  LTC68042cell_nextVoltages() will do the
     //    best it can.
-    #define LTC_TRIGGERMODE_CONTINUOUS      0
+    #define LTC_TRIGGERMODE_ROUND_ROBIN     0
     #define LTC_TRIGGERMODE_TRIGGERED       1
     #define LTC_TRIGGERMODE_FORCE_TRIGGERED 2
 
-    #define LTC_STATE_FIRSTRUN 0
-    #define LTC_STATE_GATHER   1
-    #define LTC_STATE_PROCESS  2
-    #define LTC_STATE_GATHER_TRIGGERED   4 // not used
-    #define LTC_STATE_PROCESS_TRIGGERED  8
-    #define LTC_STATE_TRIGGER  16
+    #define LTC_STATE_FIRSTRUN           0
+    #define LTC_WAITING_FOR_ADC          1
+    #define LTC_STATE_GATHER             2
+    #define LTC_STATE_PROCESS            3
+    #define LTC_STATE_PROCESS_TRIGGERED  4
+    #define LTC_STATE_TRIGGER            5
 
-    #define GATHERING_CELL_DATA  0
-    #define CELL_DATA_PROCESSED  1
-    #define WAITING_TO_TRIGGER   2
+    #define NO__GATHERING_CELL_DATA    0
+    #define DONE__CELL_DATA_PROCESSED  1
+    #define NO__WAITING_FOR_READY      2
+    #define DONE__READY_TO_TRIGGER     2
 
     #define LTC6804_MAX_CONVERSION_TIME_ms 5 //4.43 ms in '2kHz' sampling mode
 

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.h
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.h
@@ -3,17 +3,44 @@
 
 #ifndef LTC68042cell_h
     #define LTC68042cell_h
-    
+
+    // trigger mode argument values to LTC68042cell_nextVoltages()
+    //  CONTINUOUS: trigger another acqusition as soon as possible
+    //    This mode piplines the acquisitions, so that the next acquisition can occur
+    //    (in the BMS ic's) while the data from the current one is being processed.
+    //    60 cells require 21 calls (at apropriate intervels) to LTC68042cell_nextVoltages()
+    //    for a complete acquisition cycle.
+    //  TRIGGERED: trigger an acqusition only at the next call after CELL_DATA_PROCESSED
+    //    This mode allows a acquisition to be syncronized with events outside of
+    //    LTC68042cell_nextVoltages(), and is optimum for testing cell votage changes
+    //    in response to specific events. This adds 1 extra call for a complete cycle.
+    //  FORCE_TRIGGERED: trigger an acqusition NOW, abandoning any previous acqusition
+    //    that is in process. This is optimum as the first, single, call when when
+    //    switching from CONTINUOUS to TRIGGERED to get a new acquisition without having
+    //    to take the time to complete a full call cycle on the current acquisition.
+    // NOTE: It is only appripriate to make a call with LTC_TRIGGERMODE_FORCE_TRIGGERED one
+    //       time, to start a new acquisition cycle. Following calls should be with
+    //       LTC_TRIGGERMODE_TRIGGERED until LTC68042cell_nextVoltages() returns CELL_DATA_PROCESSED.
+    // Switching between modes at any time is supported.  LTC68042cell_nextVoltages() will do the
+    //    best it can.
+    #define LTC_TRIGGERMODE_CONTINUOUS      0
+    #define LTC_TRIGGERMODE_TRIGGERED       1
+    #define LTC_TRIGGERMODE_FORCE_TRIGGERED 2
+
     #define LTC_STATE_FIRSTRUN 0
     #define LTC_STATE_GATHER   1
     #define LTC_STATE_PROCESS  2
+    #define LTC_STATE_GATHER_TRIGGERED   4 // not used
+    #define LTC_STATE_PROCESS_TRIGGERED  8
+    #define LTC_STATE_TRIGGER  16
 
-    #define GATHERING_CELL_DATA 0
-    #define CELL_DATA_PROCESSED 1
+    #define GATHERING_CELL_DATA  0
+    #define CELL_DATA_PROCESSED  1
+    #define WAITING_TO_TRIGGER   2
 
     #define LTC6804_MAX_CONVERSION_TIME_ms 5 //4.43 ms in '2kHz' sampling mode
 
-    bool LTC68042cell_nextVoltages(void);
+    uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode);
     void LTC68042cell_acquireAllCellVoltages(void);
 
 #endif

--- a/Firmware/firmwareLiBCM/src/key.cpp
+++ b/Firmware/firmwareLiBCM/src/key.cpp
@@ -111,7 +111,6 @@ void keyOn_coldBootTasks(void)
     gpio_turnPowerSensors_on();
     LTC68042configure_pulseChipSelectLow(SPECIFIED_MAX_WAKEUP_TIME_LTCCORE_MICROSECONDS); //wake LTC6804
     LTC68042cell_nextVoltages(); //first call starts LTC6804 conversion
-    uint32_t timeSinceLTC6804conversionStarted_us = millis();
 
     //other startup initialization tasks
     vPackSpoof_handleKeyON();

--- a/Firmware/firmwareLiBCM/src/key.cpp
+++ b/Firmware/firmwareLiBCM/src/key.cpp
@@ -119,9 +119,8 @@ void keyOn_coldBootTasks(void)
     METSCI_enable();
     LED(3,ON);
 
-    //process cell voltages
-    while(millis() - timeSinceLTC6804conversionStarted_us < LTC6804_MAX_CONVERSION_TIME_ms) { ; } //wait for conversion to finish
-    while(LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //read all cell voltages back
+    //read and process cell voltages, waiting for conversion to finish if needed
+    while(LTC68042cell_nextVoltages() != DONE__CELL_DATA_PROCESSED) { ; } //read all cell voltages back
     vPackSpoof_setVoltage();
     SoC_setBatteryStateNow_percent(SoC_estimateFromRestingCellVoltage_percent());
     BATTSCI_enable(); //must occur after we have valid Vcell data

--- a/Firmware/firmwareLiBCM/src/key.cpp
+++ b/Firmware/firmwareLiBCM/src/key.cpp
@@ -110,7 +110,7 @@ void keyOn_coldBootTasks(void)
     //initialize hardware
     gpio_turnPowerSensors_on();
     LTC68042configure_pulseChipSelectLow(SPECIFIED_MAX_WAKEUP_TIME_LTCCORE_MICROSECONDS); //wake LTC6804
-    LTC68042cell_nextVoltages(); //first call starts LTC6804 conversion
+    LTC68042cell_nextVoltages(LTC_TRIGGERMODE_CONTINUOUS); //first call starts LTC6804 conversion
     uint32_t timeSinceLTC6804conversionStarted_us = millis();
 
     //other startup initialization tasks
@@ -119,9 +119,8 @@ void keyOn_coldBootTasks(void)
     METSCI_enable();
     LED(3,ON);
 
-    //process cell voltages
-    while(millis() - timeSinceLTC6804conversionStarted_us < LTC6804_MAX_CONVERSION_TIME_ms) { ; } //wait for conversion to finish
-    while(LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //read all cell voltages back
+    //read and process cell voltages, waiting for conversion to finish if needed
+    while(LTC68042cell_nextVoltages(LTC_TRIGGERMODE_CONTINUOUS) != CELL_DATA_PROCESSED) { ; } //read all cell voltages back
     vPackSpoof_setVoltage();
     SoC_setBatteryStateNow_percent(SoC_estimateFromRestingCellVoltage_percent());
     BATTSCI_enable(); //must occur after we have valid Vcell data

--- a/Firmware/firmwareLiBCM/src/key.cpp
+++ b/Firmware/firmwareLiBCM/src/key.cpp
@@ -110,7 +110,7 @@ void keyOn_coldBootTasks(void)
     //initialize hardware
     gpio_turnPowerSensors_on();
     LTC68042configure_pulseChipSelectLow(SPECIFIED_MAX_WAKEUP_TIME_LTCCORE_MICROSECONDS); //wake LTC6804
-    LTC68042cell_nextVoltages(LTC_TRIGGERMODE_CONTINUOUS); //first call starts LTC6804 conversion
+    LTC68042cell_nextVoltages(LTC_TRIGGERMODE_ROUND_ROBIN); //first call starts LTC6804 conversion
     uint32_t timeSinceLTC6804conversionStarted_us = millis();
 
     //other startup initialization tasks
@@ -120,7 +120,7 @@ void keyOn_coldBootTasks(void)
     LED(3,ON);
 
     //read and process cell voltages, waiting for conversion to finish if needed
-    while(LTC68042cell_nextVoltages(LTC_TRIGGERMODE_CONTINUOUS) != CELL_DATA_PROCESSED) { ; } //read all cell voltages back
+    while(LTC68042cell_nextVoltages(LTC_TRIGGERMODE_ROUND_ROBIN) != DONE__CELL_DATA_PROCESSED) { ; } //read all cell voltages back
     vPackSpoof_setVoltage();
     SoC_setBatteryStateNow_percent(SoC_estimateFromRestingCellVoltage_percent());
     BATTSCI_enable(); //must occur after we have valid Vcell data


### PR DESCRIPTION
All cell data is acquired and processed via calls to LTC68042cell_nextVoltages().
The prior code is well optimized for continuous cell data acquisition, where the next acquisition is started as soon as all of the data from the current one has been gathered, and that new acquisition then runs in parallel with the data processing step.
However, for BIST code where conditions are changed for test purposes, and the test then needs to do an acquisition to look for effects, two full acquisition cycles would be required: the first to gather and process (and then discard) the data from the "too early" acquisition, and then another cycle to gather and process the desired cell data. This is inefficient.
A new mode argument is added to LTC68042cell_nextVoltages() to allow operating as before (“TRIGGERMODE_ROUND_ROBIN” mode), or to short-circuit any prior cycle as quickly as possible (“TRIGGERMODE_FORCE_TRIGGERED“ mode), and then to proceed with a single direct trigger, wait, gather, process acquisition cycle (“TRIGGERMODE_TRIGGERED” mode).
Transitions between LTC68042cell_nextVoltages() modes are supported at any time.