### PR TITLE
Add a basic confidence test to detect open cell sense cable connections

### DIFF
--- a/Firmware/firmwareLiBCM/firmwareLiBCM.ino
+++ b/Firmware/firmwareLiBCM/firmwareLiBCM.ino
@@ -4,7 +4,7 @@
 
 #include "src/libcm.h"
 
-void setup() 
+void setup()
 {
     //getting here takes ~02 milliseconds after poweron reset
     //getting here takes ~16 milliseconds after IMA switch on
@@ -23,7 +23,7 @@ void setup()
     if (gpio_keyStateNow() == GPIO_KEY_ON) { keyOn_coldBootTasks();          }
     else                                   { debugUSB_printWelcomeMessage(); }
 
-    bringupTester_gridcharger(); 
+    bringupTester_gridcharger();
     bringupTester_motherboard();
 
     wdt_enable(WDTO_2S); //set watchdog reset vector to 2 seconds
@@ -48,7 +48,7 @@ void loop()
     {
         if (eeprom_expirationStatus_get() != FIRMWARE_EXPIRED) { BATTSCI_sendFrames(); } //P1648 when firmware expired
 
-        LTC68042cell_nextVoltages(); //round-robin handler measures QTY3 cell voltages per call
+        LTC68042cell_nextVoltages(LTC_TRIGGERMODE_CONTINUOUS); //round-robin handler measures QTY3 cell voltages per call
         METSCI_processLatestFrame();
         adc_updateBatteryCurrent();
         vPackSpoof_setVoltage();

--- a/Firmware/firmwareLiBCM/firmwareLiBCM.ino
+++ b/Firmware/firmwareLiBCM/firmwareLiBCM.ino
@@ -48,7 +48,7 @@ void loop()
     {
         if (eeprom_expirationStatus_get() != FIRMWARE_EXPIRED) { BATTSCI_sendFrames(); } //P1648 when firmware expired
 
-        LTC68042cell_nextVoltages(LTC_TRIGGERMODE_CONTINUOUS); //round-robin handler measures QTY3 cell voltages per call
+        LTC68042cell_nextVoltages(LTC_TRIGGERMODE_ROUND_ROBIN); //round-robin handler measures QTY3 cell voltages per call
         METSCI_processLatestFrame();
         adc_updateBatteryCurrent();
         vPackSpoof_setVoltage();

--- a/Firmware/firmwareLiBCM/src/BringupTester.cpp
+++ b/Firmware/firmwareLiBCM/src/BringupTester.cpp
@@ -270,6 +270,7 @@ bool testDischargeFETs(void)
         delay(500); //wait for filter network to settle
 
         LTC68042cell_acquireAllCellVoltages();
+        LTC68042cell_acquireAllCellVoltages();
 
         for (uint8_t ii=0; ii<TOTAL_IC; ii++) { debugUSB_printOneICsCellVoltages( ii, 3); }
     }

--- a/Firmware/firmwareLiBCM/src/BringupTester.cpp
+++ b/Firmware/firmwareLiBCM/src/BringupTester.cpp
@@ -8,7 +8,7 @@
 //////////////////////////////////////////////////////////////////
 
 void serialUSB_waitForEmptyBuffer(void)
-{   
+{
     //send all buffered serial data before starting each test (in case of brownout/reset)
     while (Serial.availableForWrite() != 63) { ; } //do nothing
 }
@@ -42,7 +42,7 @@ void bringupTester_gridcharger(void)
 {
     #ifdef RUN_BRINGUP_TESTER_GRIDCHARGER
         while (1) //this function never returns
-        {       
+        {
             Serial.print(F("\nRunning Grid Charger Test: "));
             #ifdef GRIDCHARGER_IS_1500W
                 Serial.print(F("GRIDCHARGER_IS_1500W"));
@@ -204,7 +204,7 @@ bool testLTC6804isoSPI(void)
     delay(50);
 
     Serial.print(F("\nLTC6804 - VREF test: "));
-    if (LTC6804gpio_areAllVoltageReferencesPassing() == true) { Serial.print(F("\nresult: passed")); } 
+    if (LTC6804gpio_areAllVoltageReferencesPassing() == true) { Serial.print(F("\nresult: passed")); }
     else                                                      { Serial.print(F("\nresult: FAIL!! !! !! !!")); didTestFail = true; }
 
     for (int ii=0; ii<5; ii++) { LTC68042cell_acquireAllCellVoltages(); delay(10); } //generate isoSPI traffic to check for errors
@@ -266,17 +266,16 @@ bool testDischargeFETs(void)
         {
             LTC68042configure_setBalanceResistors(FIRST_IC_ADDR + ii, cellDischargeBitmaps[bitmapPattern], LTC6804_DISCHARGE_TIMEOUT_02_SECONDS);
         }
-            
+
         delay(500); //wait for filter network to settle
 
-        LTC68042cell_acquireAllCellVoltages();
         LTC68042cell_acquireAllCellVoltages();
 
         for (uint8_t ii=0; ii<TOTAL_IC; ii++) { debugUSB_printOneICsCellVoltages( ii, 3); }
     }
 
     return didTestFail;
-    
+
     //JTS2do: Automate test results.
     //right now you must paste the results into the following spreadsheet and verify everything is working properly:
     //~/Honda_Insight_LiBCM/Test Fixtures/LTC6804 Discharge Tester Analysis.ods
@@ -290,11 +289,11 @@ bool testLiDisplayLoopback(void)
 
     Serial.print(F("\nLiDisplay loopback test: "));
     serialUSB_waitForEmptyBuffer();
-        
+
     Serial1.begin(57600,SERIAL_8N1);
 
     while (Serial1.available() != 0) { Serial1.read(); } //empty buffer
-    
+
     for (char charToLoopback = 'A'; charToLoopback <= 'Z'; charToLoopback++)
     {
         Serial1.write(charToLoopback);

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -319,10 +319,8 @@ bool LTC68042cell_nextVoltages(void)
 
 //Only call when keyOFF //takes too long to execute when keyON (causes check engine light)
 //Results are stored in "LTC68042_results.c"
-//JTS2doNext: rewrite to remove double call hack
 void LTC68042cell_acquireAllCellVoltages(void)
 {
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //clear old data (if any)
     while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //gather new data
 }
 

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -13,8 +13,6 @@
 uint16_t cellVoltages_counts[TOTAL_IC][CELLS_PER_IC];
 uint8_t  chipAddress = FIRST_IC_ADDR;
 char     cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
-bool     conversionInProcess = false; //used to speed up execution of conversion complete test
-uint32_t conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
 uint32_t conversionStart_us = 0;
 
 //JTS2doLater: Add cell voltage test that sets user alert if a cell voltage suddenly changes from 'balanced' to 'majorly imbalanced'
@@ -22,7 +20,7 @@ uint32_t conversionStart_us = 0;
 /////////////////////////////////////////////////////////////////////////////////////////
 
 //tell all LTC68042 ICs to measure all cells
-void startCellConversion(void)
+void startCellConversionAndResetCellCounters(void)
 {
     uint8_t cmd[4];
 
@@ -43,10 +41,8 @@ void startCellConversion(void)
     LTC68042configure_spiWrite(4,cmd); //send 'adcv' command to all LTC6804s (broadcast command)
 
     conversionStart_us = micros();
-    conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
     chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
     cellVoltageRegister = 'A';
-    conversionInProcess = true;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -245,108 +241,139 @@ void processAllCellVoltages(void)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+bool checkIfAdcWaitOver(void)
+{
+   if ((LTC6804_MAX_CONVERSION_TIME_ms * 1000) < (micros() - conversionStart_us)) { return true;  }
+   else                                                                           { return false; }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+//for triggerMode LTC_TRIGGERMODE_ROUND_ROBIN or LTC_TRIGGERMODE_TRIGGERED,
 //either gather next QTY3 cell voltages from LTC6804, or process a complete batch of returned cell voltage data.
 //raw cell voltages are stored in file-scoped "cellVoltages_counts[][]"" array
 //latest validated results are stored in a different, globally-accessible array inside "LTC68042_result.c"
-//Example with QTY48 cells:
+//for triggerMode LTC_TRIGGERMODE_FORCE_TRIGGERED, abandons any existing conversion and moves to a "ready to trigger" state (see note)
+//  see LTC68042cell.h for more explanation
+//Example with QTY48 cells (except if triggerMode is LTC_TRIGGERMODE_FORCE_TRIGGERED):
 //  -the absolute first call starts a conversion.
-//  After that, the behavior is as follows:
+//  After that, the behavior is as follows (see note):
 //  -the next sixteen calls ( (48 cells) / (3 cells per call) = 16 calls ) read back QTY48 cell voltages.
-//  -The seventeenth call performs all pack voltage math and stores valid results in LTC68042_result.c
+//  -if triggerMode is LTC_TRIGGERMODE_ROUND_ROBIN, the last "read back" call also starts another conversion
+//  -the seventeenth call performs all pack voltage math and stores valid results in LTC68042_result.c
+//  -if triggerMode is LTC_TRIGGERMODE_TRIGGERED, an eighteenth call is required to start another conversion
 //
-//returns GATHERING_CELL_DATA while gathering data, CELL_DATA_PROCESSED each time all data is processed
+// Note: if called too soon after a conversion is triggered, the state machine will return immediately, so more
+//   calls will be required until the wait time expires.
+//if called with triggerMode LTC_TRIGGERMODE_ROUND_ROBIN or LTC_TRIGGERMODE_TRIGGERED,
+// returns NO__GATHERING_CELL_DATA while gathering data, DONE__CELL_DATA_PROCESSED each time all data is processed
+//if called with triggerMode LTC_TRIGGERMODE_FORCE_TRIGGERED,
+// returns DONE__READY_TO_TRIGGER if state machine is ready to trigger a conversion on the next call, else
+//   NO__WAITING_FOR_READY if a wait is required
 uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 {
     static uint8_t presentState = LTC_STATE_FIRSTRUN;
-    uint8_t cellVoltageDataStatus = GATHERING_CELL_DATA;
+    uint8_t cellVoltageDataStatus = NO__GATHERING_CELL_DATA;
 
     if (LTC68042configure_wakeup() == LTC6804_CORE_JUST_WOKE_UP) { presentState = LTC_STATE_FIRSTRUN; }
 
-    if ((presentState & LTC_STATE_TRIGGER) || (LTC_TRIGGERMODE_FORCE_TRIGGERED == triggerMode))
+    if (LTC_TRIGGERMODE_FORCE_TRIGGERED == triggerMode)
     {
-        if ( ( ! conversionInProcess) || (conversionExpectedDuration_us < (micros() - conversionStart_us)) )
+        // in almost all cases, we do:
+        presentState = LTC_STATE_TRIGGER;
+        cellVoltageDataStatus = DONE__READY_TO_TRIGGER;
+
+        // now handle exceptions:
+        if      (LTC_STATE_FIRSTRUN == presentState) { LTC68042configure_programVolatileDefaults(); }
+        else if (LTC_WAITING_FOR_ADC == presentState)
         {
-            //then no conversion is in process or last one has completed
-            startCellConversion();
-            presentState = LTC_STATE_GATHER;
+            if (false == checkIfAdcWaitOver())
+            {
+                // then we still need to wait
+                //presentState = LTC_WAITING_FOR_ADC; // stay in current state
+                cellVoltageDataStatus = NO__WAITING_FOR_READY;
+            }
         }
-        else
+        else if (LTC_STATE_PROCESS == presentState)
         {
-            //then we need to wait for it to complete before starting ours, so don't advance presentState, and
-            cellVoltageDataStatus = WAITING_TO_TRIGGER;
+            //then a conversion might be in process, so
+            presentState = LTC_WAITING_FOR_ADC;
+            cellVoltageDataStatus = NO__WAITING_FOR_READY;
         }
     }
 
-    else if (presentState & LTC_STATE_GATHER)
-    { //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
-        // but don't gather data or advance the state if the  current conversion is not complete (should not usually be necessary)
-        if ( ( ! conversionInProcess) || (conversionExpectedDuration_us < (micros() - conversionStart_us)) )
+    //for LTC_WAITING_FOR_ADC: don't gather data or advance the state if the current
+    //  conversion is not complete (should not usually be necessary in key-on mode)
+    else if ( ( (LTC_WAITING_FOR_ADC == presentState) && (true == checkIfAdcWaitOver()) ) ||
+              (LTC_STATE_GATHER == presentState)
+            )
+    {
+        //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
+        validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
+
+        //determine which LTC68042 IC & CVR to read next
+        cellVoltageRegister++;
+        if (cellVoltageRegister >= 'E')
         {
-            //then no conversion is in process or last one has completed
-            conversionInProcess = false;
-
-            validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
-
-            //determine which LTC68042 IC & CVR to read next
-            cellVoltageRegister++;
-            if (cellVoltageRegister >= 'E')
+            //LTC6804 only has registers A,B,C,D
+            cellVoltageRegister = 'A'; //reset back to first CVR
+            if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
             {
-                //LTC6804 only has registers A,B,C,D
-                cellVoltageRegister = 'A'; //reset back to first CVR
-                if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
+                //last "LTC_STATE_GATHER" call for this cycle
+                //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
+                if (LTC_TRIGGERMODE_ROUND_ROBIN == triggerMode)
                 {
-                    //last "LTC_STATE_GATHER" call for this cycle
-                    //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
-                    if (LTC_TRIGGERMODE_CONTINUOUS == triggerMode)
-                    {
-                        startCellConversion(); //start the next cell conversion //takes a while to finish
-                        presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
-                    }
-                    else if (LTC_TRIGGERMODE_TRIGGERED == triggerMode)
-                    {
-                        presentState = LTC_STATE_PROCESS_TRIGGERED; //all cell voltages gathered.  Process data on next run, but trigger after that
-                    }
-                    else
-                    {
-                        Serial.print(F("\nillegal LTC68042cell trigger mode"));
-                        while (1) {;} //hang here until watchdog resets.
-                    }
+                    startCellConversionAndResetCellCounters(); //start the next cell conversion //takes a while to finish
+                    presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
+                }
+                else if (LTC_TRIGGERMODE_TRIGGERED == triggerMode)
+                {
+                    presentState = LTC_STATE_PROCESS_TRIGGERED; //all cell voltages gathered.  Process data on next run, but trigger after that
+                }
+                else
+                {
+                    Serial.print(F("\nillegal LTC68042cell trigger mode"));
+                    while (1) {;} //hang here until watchdog resets.
                 }
             }
         }
     }
 
-    else if (presentState & (LTC_STATE_PROCESS | LTC_STATE_PROCESS_TRIGGERED))
+    else if ((LTC_STATE_PROCESS == presentState) || (LTC_STATE_PROCESS_TRIGGERED == presentState))
     {
         //all cell voltages read...
-        if ((presentState & LTC_STATE_PROCESS_TRIGGERED) && (LTC_TRIGGERMODE_CONTINUOUS == triggerMode))
+
+        //handle transision from LTC_STATE_PROCESS_TRIGGERED to LTC_TRIGGERMODE_ROUND_ROBIN
+        if ((LTC_STATE_PROCESS_TRIGGERED == presentState) && (LTC_TRIGGERMODE_ROUND_ROBIN == triggerMode))
         {
-            //then triggerMode changed from TRIGGERED to CONTINUOUS, allow the change of mode,
-            //  and start a conversion here to get a head start...
-            startCellConversion();
-            presentState = LTC_STATE_PROCESS; //for next state determination
-        }
-        else if ((presentState & LTC_STATE_PROCESS) && (LTC_STATE_PROCESS_TRIGGERED == triggerMode))
-        {
-            //then triggerMode changed from CONTINUOUS to TRIGGERED: an extraneous trigger has already happened,
-            //  but change to presentState = LTC_STATE_PROCESS_TRIGGERED, and wait at start of LTC_STATE_TRIGGER
-            //  might happen
-            presentState = LTC_STATE_PROCESS_TRIGGERED; //for next state determination
+            //then triggerMode changed from TRIGGERED to ROUND_ROBIN: allow the change of mode,
+            //  and start a belated conversion ...
+            startCellConversionAndResetCellCounters();
+            //we are now effectively back to ROUND_ROBIN, so this is needed for next state determination coming right up
+            presentState = LTC_STATE_PROCESS;
         }
 
         processAllCellVoltages(); //do math and store in LTC68042_result.c
-        cellVoltageDataStatus = CELL_DATA_PROCESSED;
+        cellVoltageDataStatus = DONE__CELL_DATA_PROCESSED;
 
-        if (presentState & LTC_STATE_PROCESS_TRIGGERED) { presentState = LTC_STATE_TRIGGER; } //trigger on next run
-        else                                            { presentState = LTC_STATE_GATHER;  } //gather data on next run (a trigger has already happened)
+        if (LTC_STATE_PROCESS_TRIGGERED == presentState) { presentState = LTC_STATE_TRIGGER;   } //trigger on next run
+        else                                             { presentState = LTC_WAITING_FOR_ADC; } //wait if needed on next run (a trigger has already happened)
     }
 
-    else if (presentState == LTC_STATE_FIRSTRUN)
+    else if (LTC_STATE_FIRSTRUN == presentState)
     {
         //LTC6804 ICs were previously off
         LTC68042configure_programVolatileDefaults();
-        startCellConversion();
-        presentState = LTC_STATE_GATHER;
+        startCellConversionAndResetCellCounters();
+        presentState = LTC_WAITING_FOR_ADC;
+    }
+
+    else if (LTC_STATE_TRIGGER == presentState)
+    {
+        //then trigger a conversion
+        //  Note: by design, can't get to this state while a conversion is in process, so no check is performent
+        startCellConversionAndResetCellCounters();
+        presentState = LTC_WAITING_FOR_ADC;
     }
 
     else
@@ -364,8 +391,8 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 //Results are stored in "LTC68042_results.c"
 void LTC68042cell_acquireAllCellVoltages(void)
 {
-    while (LTC68042cell_nextVoltages(LTC_TRIGGERMODE_FORCE_TRIGGERED) == WAITING_TO_TRIGGER) { ; } //abandon any in-process acquisition (waiting for it to complete, if needed)
-    while (LTC68042cell_nextVoltages(LTC_TRIGGERMODE_TRIGGERED) != CELL_DATA_PROCESSED) { ; } //gather new data
+    while (LTC68042cell_nextVoltages(LTC_TRIGGERMODE_FORCE_TRIGGERED) != DONE__READY_TO_TRIGGER)    { ; } //abandon any in-process acquisition (waiting for it to complete, if needed)
+    while (LTC68042cell_nextVoltages(LTC_TRIGGERMODE_TRIGGERED)       != DONE__CELL_DATA_PROCESSED) { ; } //gather new data
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -11,7 +11,7 @@
 //  Example: cellVoltages_counts[0][ 1] is IC_1 cell_02
 //  Example: cellVoltages_counts[3][11] is IC_4 cell_12
 uint16_t cellVoltages_counts[TOTAL_IC][CELLS_PER_IC];
-uint32_t conversionStart_ms = 0;
+uint32_t conversionStart_us = 0;
 
 //JTS2doLater: Add cell voltage test that sets user alert if a cell voltage suddenly changes from 'balanced' to 'majorly imbalanced'
 
@@ -37,7 +37,7 @@ void startCellConversion(void)
     cmd[3] = (uint8_t)(temp_pec);
 
     LTC68042configure_spiWrite(4,cmd); //send 'adcv' command to all LTC6804s (broadcast command)
-    conversionStart_ms = millis();
+    conversionStart_us = micros();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -236,73 +236,93 @@ void processAllCellVoltages(void)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+bool checkIfAdcWaitOver(void)
+{
+    if ((LTC6804_MAX_CONVERSION_TIME_ms * 1000) < (micros() - conversionStart_us)) { return true;  }
+    else                                                                           { return false; }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+void doCellDataGather(uint8_t * presentState)
+{ //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
+    //round-robin state handlers
+    static uint8_t chipAddress = FIRST_IC_ADDR;
+    static char cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
+
+    validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
+
+    //determine which LTC68042 IC & CVR to read next
+    cellVoltageRegister++;
+    if (cellVoltageRegister >= 'E')
+    {
+        //LTC6804 only has registers A,B,C,D
+        cellVoltageRegister = 'A'; //reset back to first CVR
+        if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
+        {
+            //last "LTC_STATE_GATHER" call for this cycle
+            //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
+            startCellConversion(); //start the next cell conversion //takes a while to finish
+            chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
+            *presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
 //either gather next QTY3 cell voltages from LTC6804, or process a complete batch of returned cell voltage data.
 //raw cell voltages are stored in file-scoped "cellVoltages_counts[][]"" array
 //latest validated results are stored in a different, globally-accessible array inside "LTC68042_result.c"
 //Example with QTY48 cells:
 //  -the absolute first call starts a conversion.
-//  After that, the behavior is as follows:
+//  After that, the behavior is as follows (see note):
 //  -the next sixteen calls ( (48 cells) / (3 cells per call) = 16 calls ) read back QTY48 cell voltages.
-//  -The seventeenth call performs all pack voltage math and stores valid results in LTC68042_result.c
+//    (the last "read back" call also starts another conversion)
+//  -the seventeenth call performs all pack voltage math and stores valid results in LTC68042_result.c
 //
-//returns false while gathering data, true each time all data is processed
+// Note: if called too soon after a conversion is triggered, the state machine will return immediately, so more
+//   calls will be required until the wait time expires.
+// returns NO__GATHERING_CELL_DATA while gathering data, DONE__CELL_DATA_PROCESSED each time all data is processed
 bool LTC68042cell_nextVoltages(void)
 {
     static uint8_t presentState = LTC_STATE_FIRSTRUN;
-    static bool conversionInProcess = false; //used to speed up execution of conversion complete test
-    bool cellVoltageDataStatus = GATHERING_CELL_DATA;
+    bool cellVoltageDataStatus = NO__GATHERING_CELL_DATA;
 
     if (LTC68042configure_wakeup() == LTC6804_CORE_JUST_WOKE_UP) { presentState = LTC_STATE_FIRSTRUN; }
 
-    if (presentState == LTC_STATE_GATHER)
-    { //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
-        // but don't gather data or advance the state if the  current conversion is not complete (should not usually be necessary)
-        if ( ( ! conversionInProcess) || (LTC6804_MAX_CONVERSION_TIME_ms < (millis() - conversionStart_ms)) )
+    //for LTC_WAITING_FOR_ADC: if done waiting, fall through to GATHER
+    //  don't gather data or advance the state if the current
+    //  conversion is not complete (should not usually be necessary in key-on mode)
+    if (LTC_WAITING_FOR_ADC == presentState)
+    {
+        if (true == checkIfAdcWaitOver())
         {
-            //then no conversion is in process or it has completed
-            conversionInProcess = false;
-
-            //round-robin state handlers
-            static uint8_t chipAddress = FIRST_IC_ADDR;
-            static char cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
-
-            validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
-
-            //determine which LTC68042 IC & CVR to read next
-            cellVoltageRegister++;
-            if (cellVoltageRegister >= 'E')
-            {
-                //LTC6804 only has registers A,B,C,D
-                cellVoltageRegister = 'A'; //reset back to first CVR
-
-                if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
-                {
-                    //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
-                    startCellConversion(); //start the next cell conversion //takes a while to finish
-                    conversionInProcess = true;
-
-                    chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
-                    presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
-                }
-            }
+            //then wait is over
+            doCellDataGather(&presentState); // do first gather
+            presentState = LTC_STATE_GATHER;
         }
+        //else
+            //presentState = LTC_WAITING_FOR_ADC; // hold in current state
     }
 
-    else if (presentState == LTC_STATE_PROCESS)
+    else if (LTC_STATE_GATHER == presentState) { doCellDataGather(&presentState); }
+
+    else if (LTC_STATE_PROCESS == presentState)
     {
         //all cell voltages read...
         processAllCellVoltages(); //do math and store in LTC68042_result.c
-        cellVoltageDataStatus = CELL_DATA_PROCESSED;
-        presentState = LTC_STATE_GATHER; //gather data on next run
+        cellVoltageDataStatus = DONE__CELL_DATA_PROCESSED;
+        presentState = LTC_WAITING_FOR_ADC; //wait if needed on next run (a trigger has already happened)
+
     }
 
-    else if (presentState == LTC_STATE_FIRSTRUN)
+    else if (LTC_STATE_FIRSTRUN == presentState)
     {
         //LTC6804 ICs were previously off
         LTC68042configure_programVolatileDefaults();
         startCellConversion();
-        conversionInProcess = true;
-        presentState = LTC_STATE_GATHER;
+        presentState = LTC_WAITING_FOR_ADC;
     }
 
     else
@@ -321,8 +341,8 @@ bool LTC68042cell_nextVoltages(void)
 //JTS2doNext: rewrite to remove double call hack
 void LTC68042cell_acquireAllCellVoltages(void)
 {
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //clear old data (if any)
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //gather new data
+    while (LTC68042cell_nextVoltages() != DONE__CELL_DATA_PROCESSED) { ; } //clear old data (if any)
+    while (LTC68042cell_nextVoltages() != DONE__CELL_DATA_PROCESSED) { ; } //gather new data
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -244,11 +244,12 @@ bool checkIfAdcWaitOver(void)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-void doCellDataGather(uint8_t * presentState)
+uint8_t doCellDataGather(void)
 { //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
     //round-robin state handlers
     static uint8_t chipAddress = FIRST_IC_ADDR;
     static char cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
+    uint8_t nextPresentState = LTC_STATE_GATHER; // default to remaining in gather state
 
     validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
 
@@ -264,9 +265,10 @@ void doCellDataGather(uint8_t * presentState)
             //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
             startCellConversion(); //start the next cell conversion //takes a while to finish
             chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
-            *presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
+            nextPresentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
         }
     }
+    return nextPresentState;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -299,14 +301,13 @@ bool LTC68042cell_nextVoltages(void)
         if (true == checkIfAdcWaitOver())
         {
             //then wait is over
-            doCellDataGather(&presentState); // do first gather
-            presentState = LTC_STATE_GATHER;
+            presentState = doCellDataGather(); // do first gather
         }
         //else
             //presentState = LTC_WAITING_FOR_ADC; // hold in current state
     }
 
-    else if (LTC_STATE_GATHER == presentState) { doCellDataGather(&presentState); }
+    else if (LTC_STATE_GATHER == presentState) { presentState = doCellDataGather(); }
 
     else if (LTC_STATE_PROCESS == presentState)
     {

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -243,8 +243,43 @@ void processAllCellVoltages(void)
 
 bool checkIfAdcWaitOver(void)
 {
-   if ((LTC6804_MAX_CONVERSION_TIME_ms * 1000) < (micros() - conversionStart_us)) { return true;  }
-   else                                                                           { return false; }
+    if ((LTC6804_MAX_CONVERSION_TIME_ms * 1000) < (micros() - conversionStart_us)) { return true;  }
+    else                                                                           { return false; }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+void doCellDataGather(uint8_t triggerMode, uint8_t * presentState)
+{
+    //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
+    validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
+
+    //determine which LTC68042 IC & CVR to read next
+    cellVoltageRegister++;
+    if (cellVoltageRegister >= 'E')
+    {
+        //LTC6804 only has registers A,B,C,D
+        cellVoltageRegister = 'A'; //reset back to first CVR
+        if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
+        {
+            //last "LTC_STATE_GATHER" call for this cycle
+            //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
+            if (LTC_TRIGGERMODE_ROUND_ROBIN == triggerMode)
+            {
+                startCellConversionAndResetCellCounters(); //start the next cell conversion //takes a while to finish
+                *presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
+            }
+            else if (LTC_TRIGGERMODE_TRIGGERED == triggerMode)
+            {
+                *presentState = LTC_STATE_PROCESS_TRIGGERED; //all cell voltages gathered.  Process data on next run, but trigger after that
+            }
+            else
+            {
+                Serial.print(F("\nillegal LTC68042cell trigger mode"));
+                while (1) {;} //hang here until watchdog resets.
+            }
+        }
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -279,15 +314,21 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 
     if (LTC_TRIGGERMODE_FORCE_TRIGGERED == triggerMode)
     {
-        // in almost all cases, we do:
-        presentState = LTC_STATE_TRIGGER;
-        cellVoltageDataStatus = DONE__READY_TO_TRIGGER;
-
-        // now handle exceptions:
-        if      (LTC_STATE_FIRSTRUN == presentState) { LTC68042configure_programVolatileDefaults(); }
+        if      (LTC_STATE_FIRSTRUN == presentState)
+        {
+            LTC68042configure_programVolatileDefaults();
+            presentState = LTC_STATE_TRIGGER;
+            cellVoltageDataStatus = DONE__READY_TO_TRIGGER;
+        }
         else if (LTC_WAITING_FOR_ADC == presentState)
         {
-            if (false == checkIfAdcWaitOver())
+            if (true == checkIfAdcWaitOver())
+            {
+                //then wait is over
+                presentState = LTC_STATE_TRIGGER;
+                cellVoltageDataStatus = DONE__READY_TO_TRIGGER;
+            }
+            else
             {
                 // then we still need to wait
                 //presentState = LTC_WAITING_FOR_ADC; // stay in current state
@@ -300,44 +341,29 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
             presentState = LTC_WAITING_FOR_ADC;
             cellVoltageDataStatus = NO__WAITING_FOR_READY;
         }
-    }
-
-    //for LTC_WAITING_FOR_ADC: don't gather data or advance the state if the current
-    //  conversion is not complete (should not usually be necessary in key-on mode)
-    else if ( ( (LTC_WAITING_FOR_ADC == presentState) && (true == checkIfAdcWaitOver()) ) ||
-              (LTC_STATE_GATHER == presentState)
-            )
-    {
-        //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
-        validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
-
-        //determine which LTC68042 IC & CVR to read next
-        cellVoltageRegister++;
-        if (cellVoltageRegister >= 'E')
+        else
         {
-            //LTC6804 only has registers A,B,C,D
-            cellVoltageRegister = 'A'; //reset back to first CVR
-            if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
-            {
-                //last "LTC_STATE_GATHER" call for this cycle
-                //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
-                if (LTC_TRIGGERMODE_ROUND_ROBIN == triggerMode)
-                {
-                    startCellConversionAndResetCellCounters(); //start the next cell conversion //takes a while to finish
-                    presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
-                }
-                else if (LTC_TRIGGERMODE_TRIGGERED == triggerMode)
-                {
-                    presentState = LTC_STATE_PROCESS_TRIGGERED; //all cell voltages gathered.  Process data on next run, but trigger after that
-                }
-                else
-                {
-                    Serial.print(F("\nillegal LTC68042cell trigger mode"));
-                    while (1) {;} //hang here until watchdog resets.
-                }
-            }
+            // in all other cases, we do:
+            presentState = LTC_STATE_TRIGGER;
+            cellVoltageDataStatus = DONE__READY_TO_TRIGGER;
         }
     }
+
+    //for LTC_WAITING_FOR_ADC: if done waiting, fall through to GATHERdon't gather data or advance the state if the current
+    //  conversion is not complete (should not usually be necessary in key-on mode)
+    else if (LTC_WAITING_FOR_ADC == presentState)
+    {
+        if (true == checkIfAdcWaitOver())
+        {
+            //then wait is over
+            doCellDataGather(triggerMode, &presentState); // do first gather
+            presentState = LTC_STATE_GATHER;
+        }
+        //else
+            //presentState = LTC_WAITING_FOR_ADC; // hold in current state
+    }
+
+    else if (LTC_STATE_GATHER == presentState) { doCellDataGather(triggerMode, &presentState); }
 
     else if ((LTC_STATE_PROCESS == presentState) || (LTC_STATE_PROCESS_TRIGGERED == presentState))
     {
@@ -358,6 +384,7 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 
         if (LTC_STATE_PROCESS_TRIGGERED == presentState) { presentState = LTC_STATE_TRIGGER;   } //trigger on next run
         else                                             { presentState = LTC_WAITING_FOR_ADC; } //wait if needed on next run (a trigger has already happened)
+
     }
 
     else if (LTC_STATE_FIRSTRUN == presentState)

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -11,6 +11,7 @@
 //  Example: cellVoltages_counts[0][ 1] is IC_1 cell_02
 //  Example: cellVoltages_counts[3][11] is IC_4 cell_12
 uint16_t cellVoltages_counts[TOTAL_IC][CELLS_PER_IC];
+bool     dcp_State = IS_DISCHARGE_ALLOWED_DURING_CONVERSION;
 uint8_t  chipAddress = FIRST_IC_ADDR;
 char     cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
 uint32_t conversionStart_us = 0;
@@ -19,7 +20,10 @@ uint32_t conversionStart_us = 0;
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-//tell all LTC68042 ICs to measure all cells
+void LTC68042cell_dischargeAllowedDuringConversion_set(bool dcpState) { dcp_State = dcpState; };
+
+/////////////////////////////////////////////////////////////////////////////////////////
+//tell all BMS ICs to measure all cells
 void startCellConversionAndResetCellCounters(void)
 {
     uint8_t cmd[4];
@@ -27,7 +31,7 @@ void startCellConversionAndResetCellCounters(void)
     //JTS2doLater: Replace magic numbers with #define
     //Cell Voltage conversion command
     uint8_t ADCV[2] = { ((MD_FILTERED & 0x02 ) >> 1) + 0x02,  //set bit 9 true
-                        ((MD_FILTERED & 0x01 ) << 7) + 0x60 + (IS_DISCHARGE_ALLOWED_DURING_CONVERSION<<4) + CELL_CH_ALL };
+                        ((MD_FILTERED & 0x01 ) << 7) + 0x60 + ((dcp_State ? 1 : 0)<<4) + CELL_CH_ALL };
 
     //Load 'ADCV' command into cmd array
     cmd[0] = ADCV[0];
@@ -250,10 +254,10 @@ bool checkIfAdcWaitOver(void)
 /////////////////////////////////////////////////////////////////////////////////////////
 
 uint8_t doCellDataGather(uint8_t triggerMode)
-{ //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
-    //round-robin state handlers
+{
     uint8_t nextPresentState = LTC_STATE_GATHER; // default to remaining in gather state
 
+    //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
     validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
 
     //determine which LTC68042 IC & CVR to read next
@@ -352,6 +356,8 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
         }
     }
 
+    else if (LTC_STATE_GATHER == presentState) { presentState = doCellDataGather(triggerMode); }
+
     //for LTC_WAITING_FOR_ADC: if done waiting, fall through to GATHER
     //  don't gather data or advance the state if the current
     //  conversion is not complete (should not usually be necessary in key-on mode)
@@ -365,8 +371,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
         //else
             //presentState = LTC_WAITING_FOR_ADC; // hold in current state
     }
-
-    else if (LTC_STATE_GATHER == presentState) { presentState = doCellDataGather(triggerMode); }
 
     else if ((LTC_STATE_PROCESS == presentState) || (LTC_STATE_PROCESS_TRIGGERED == presentState))
     {
@@ -387,7 +391,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 
         if (LTC_STATE_PROCESS_TRIGGERED == presentState) { presentState = LTC_STATE_TRIGGER;   } //trigger on next run
         else                                             { presentState = LTC_WAITING_FOR_ADC; } //wait if needed on next run (a trigger has already happened)
-
     }
 
     else if (LTC_STATE_FIRSTRUN == presentState)

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -11,6 +11,9 @@
 //  Example: cellVoltages_counts[0][ 1] is IC_1 cell_02
 //  Example: cellVoltages_counts[3][11] is IC_4 cell_12
 uint16_t cellVoltages_counts[TOTAL_IC][CELLS_PER_IC];
+uint8_t  chipAddress = FIRST_IC_ADDR;
+char     cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
+bool     conversionInProcess = false; //used to speed up execution of conversion complete test
 uint32_t conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
 uint32_t conversionStart_us = 0;
 
@@ -39,8 +42,11 @@ void startCellConversion(void)
 
     LTC68042configure_spiWrite(4,cmd); //send 'adcv' command to all LTC6804s (broadcast command)
 
-    conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
     conversionStart_us = micros();
+    conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
+    chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
+    cellVoltageRegister = 'A';
+    conversionInProcess = true;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -252,7 +258,6 @@ void processAllCellVoltages(void)
 uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 {
     static uint8_t presentState = LTC_STATE_FIRSTRUN;
-    static bool conversionInProcess = false; //used to speed up execution of conversion complete test
     uint8_t cellVoltageDataStatus = GATHERING_CELL_DATA;
 
     if (LTC68042configure_wakeup() == LTC6804_CORE_JUST_WOKE_UP) { presentState = LTC_STATE_FIRSTRUN; }
@@ -263,7 +268,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
         {
             //then no conversion is in process or last one has completed
             startCellConversion();
-            conversionInProcess = true;
             presentState = LTC_STATE_GATHER;
         }
         else
@@ -281,10 +285,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
             //then no conversion is in process or last one has completed
             conversionInProcess = false;
 
-            //round-robin state handlers
-            static uint8_t chipAddress = FIRST_IC_ADDR;
-            static char cellVoltageRegister = 'A'; //LTC68042 contains QTY4 CVRs (A/B/C/D)
-
             validateAndStoreNextCVR(chipAddress, cellVoltageRegister);
 
             //determine which LTC68042 IC & CVR to read next
@@ -300,7 +300,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
                     if (LTC_TRIGGERMODE_CONTINUOUS == triggerMode)
                     {
                         startCellConversion(); //start the next cell conversion //takes a while to finish
-                        conversionInProcess = true;
                         presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
                     }
                     else if (LTC_TRIGGERMODE_TRIGGERED == triggerMode)
@@ -312,8 +311,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
                         Serial.print(F("\nillegal LTC68042cell trigger mode"));
                         while (1) {;} //hang here until watchdog resets.
                     }
-
-                    chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
                 }
             }
         }
@@ -327,7 +324,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
             //then triggerMode changed from TRIGGERED to CONTINUOUS, allow the change of mode,
             //  and start a conversion here to get a head start...
             startCellConversion();
-            conversionInProcess = true;
             presentState = LTC_STATE_PROCESS; //for next state determination
         }
         else if ((presentState & LTC_STATE_PROCESS) && (LTC_STATE_PROCESS_TRIGGERED == triggerMode))
@@ -350,7 +346,6 @@ uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
         //LTC6804 ICs were previously off
         LTC68042configure_programVolatileDefaults();
         startCellConversion();
-        conversionInProcess = true;
         presentState = LTC_STATE_GATHER;
     }
 

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.cpp
@@ -11,7 +11,8 @@
 //  Example: cellVoltages_counts[0][ 1] is IC_1 cell_02
 //  Example: cellVoltages_counts[3][11] is IC_4 cell_12
 uint16_t cellVoltages_counts[TOTAL_IC][CELLS_PER_IC];
-uint32_t conversionStart_ms = 0;
+uint32_t conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
+uint32_t conversionStart_us = 0;
 
 //JTS2doLater: Add cell voltage test that sets user alert if a cell voltage suddenly changes from 'balanced' to 'majorly imbalanced'
 
@@ -37,7 +38,9 @@ void startCellConversion(void)
     cmd[3] = (uint8_t)(temp_pec);
 
     LTC68042configure_spiWrite(4,cmd); //send 'adcv' command to all LTC6804s (broadcast command)
-    conversionStart_ms = millis();
+
+    conversionExpectedDuration_us = (LTC6804_MAX_CONVERSION_TIME_ms * 1000);
+    conversionStart_us = micros();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -245,21 +248,37 @@ void processAllCellVoltages(void)
 //  -the next sixteen calls ( (48 cells) / (3 cells per call) = 16 calls ) read back QTY48 cell voltages.
 //  -The seventeenth call performs all pack voltage math and stores valid results in LTC68042_result.c
 //
-//returns false while gathering data, true each time all data is processed
-bool LTC68042cell_nextVoltages(void)
+//returns GATHERING_CELL_DATA while gathering data, CELL_DATA_PROCESSED each time all data is processed
+uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode)
 {
     static uint8_t presentState = LTC_STATE_FIRSTRUN;
     static bool conversionInProcess = false; //used to speed up execution of conversion complete test
-    bool cellVoltageDataStatus = GATHERING_CELL_DATA;
+    uint8_t cellVoltageDataStatus = GATHERING_CELL_DATA;
 
     if (LTC68042configure_wakeup() == LTC6804_CORE_JUST_WOKE_UP) { presentState = LTC_STATE_FIRSTRUN; }
 
-    if (presentState == LTC_STATE_GATHER)
+    if ((presentState & LTC_STATE_TRIGGER) || (LTC_TRIGGERMODE_FORCE_TRIGGERED == triggerMode))
+    {
+        if ( ( ! conversionInProcess) || (conversionExpectedDuration_us < (micros() - conversionStart_us)) )
+        {
+            //then no conversion is in process or last one has completed
+            startCellConversion();
+            conversionInProcess = true;
+            presentState = LTC_STATE_GATHER;
+        }
+        else
+        {
+            //then we need to wait for it to complete before starting ours, so don't advance presentState, and
+            cellVoltageDataStatus = WAITING_TO_TRIGGER;
+        }
+    }
+
+    else if (presentState & LTC_STATE_GATHER)
     { //retrieve next CVR from LTC, then validate and store in cellVoltages_counts[][] array
         // but don't gather data or advance the state if the  current conversion is not complete (should not usually be necessary)
-        if ( ( ! conversionInProcess) || (LTC6804_MAX_CONVERSION_TIME_ms < (millis() - conversionStart_ms)) )
+        if ( ( ! conversionInProcess) || (conversionExpectedDuration_us < (micros() - conversionStart_us)) )
         {
-            //then no conversion is in process or it has completed
+            //then no conversion is in process or last one has completed
             conversionInProcess = false;
 
             //round-robin state handlers
@@ -274,26 +293,56 @@ bool LTC68042cell_nextVoltages(void)
             {
                 //LTC6804 only has registers A,B,C,D
                 cellVoltageRegister = 'A'; //reset back to first CVR
-
                 if (++chipAddress >= (FIRST_IC_ADDR + TOTAL_IC))
                 {
+                    //last "LTC_STATE_GATHER" call for this cycle
                     //just finished reading last IC's last CVR... all cell voltages stored in cellVoltages_counts[][]
-                    startCellConversion(); //start the next cell conversion //takes a while to finish
-                    conversionInProcess = true;
+                    if (LTC_TRIGGERMODE_CONTINUOUS == triggerMode)
+                    {
+                        startCellConversion(); //start the next cell conversion //takes a while to finish
+                        conversionInProcess = true;
+                        presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
+                    }
+                    else if (LTC_TRIGGERMODE_TRIGGERED == triggerMode)
+                    {
+                        presentState = LTC_STATE_PROCESS_TRIGGERED; //all cell voltages gathered.  Process data on next run, but trigger after that
+                    }
+                    else
+                    {
+                        Serial.print(F("\nillegal LTC68042cell trigger mode"));
+                        while (1) {;} //hang here until watchdog resets.
+                    }
 
                     chipAddress = FIRST_IC_ADDR; //reset to first LTC IC
-                    presentState = LTC_STATE_PROCESS; //all cell voltages gathered.  Process data on next run.
                 }
             }
         }
     }
 
-    else if (presentState == LTC_STATE_PROCESS)
+    else if (presentState & (LTC_STATE_PROCESS | LTC_STATE_PROCESS_TRIGGERED))
     {
         //all cell voltages read...
+        if ((presentState & LTC_STATE_PROCESS_TRIGGERED) && (LTC_TRIGGERMODE_CONTINUOUS == triggerMode))
+        {
+            //then triggerMode changed from TRIGGERED to CONTINUOUS, allow the change of mode,
+            //  and start a conversion here to get a head start...
+            startCellConversion();
+            conversionInProcess = true;
+            presentState = LTC_STATE_PROCESS; //for next state determination
+        }
+        else if ((presentState & LTC_STATE_PROCESS) && (LTC_STATE_PROCESS_TRIGGERED == triggerMode))
+        {
+            //then triggerMode changed from CONTINUOUS to TRIGGERED: an extraneous trigger has already happened,
+            //  but change to presentState = LTC_STATE_PROCESS_TRIGGERED, and wait at start of LTC_STATE_TRIGGER
+            //  might happen
+            presentState = LTC_STATE_PROCESS_TRIGGERED; //for next state determination
+        }
+
         processAllCellVoltages(); //do math and store in LTC68042_result.c
         cellVoltageDataStatus = CELL_DATA_PROCESSED;
-        presentState = LTC_STATE_GATHER; //gather data on next run
+
+        if (presentState & LTC_STATE_PROCESS_TRIGGERED) { presentState = LTC_STATE_TRIGGER; } //trigger on next run
+        else                                            { presentState = LTC_STATE_GATHER;  } //gather data on next run (a trigger has already happened)
     }
 
     else if (presentState == LTC_STATE_FIRSTRUN)
@@ -318,11 +367,10 @@ bool LTC68042cell_nextVoltages(void)
 
 //Only call when keyOFF //takes too long to execute when keyON (causes check engine light)
 //Results are stored in "LTC68042_results.c"
-//JTS2doNext: rewrite to remove double call hack
 void LTC68042cell_acquireAllCellVoltages(void)
 {
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //clear old data (if any)
-    while (LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //gather new data
+    while (LTC68042cell_nextVoltages(LTC_TRIGGERMODE_FORCE_TRIGGERED) == WAITING_TO_TRIGGER) { ; } //abandon any in-process acquisition (waiting for it to complete, if needed)
+    while (LTC68042cell_nextVoltages(LTC_TRIGGERMODE_TRIGGERED) != CELL_DATA_PROCESSED) { ; } //gather new data
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.h
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.h
@@ -3,13 +3,15 @@
 
 #ifndef LTC68042cell_h
     #define LTC68042cell_h
-    
-    #define LTC_STATE_FIRSTRUN 0
-    #define LTC_STATE_GATHER   1
-    #define LTC_STATE_PROCESS  2
 
-    #define GATHERING_CELL_DATA 0
-    #define CELL_DATA_PROCESSED 1
+
+    #define LTC_STATE_FIRSTRUN           0
+    #define LTC_WAITING_FOR_ADC          1
+    #define LTC_STATE_GATHER             2
+    #define LTC_STATE_PROCESS            3
+
+    #define NO__GATHERING_CELL_DATA    0
+    #define DONE__CELL_DATA_PROCESSED  1
 
     #define LTC6804_MAX_CONVERSION_TIME_ms 5 //4.43 ms in '2kHz' sampling mode
 

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.h
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.h
@@ -44,5 +44,6 @@
 
     uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode);
     void LTC68042cell_acquireAllCellVoltages(void);
+    void LTC68042cell_dischargeAllowedDuringConversion_set(bool dcpState);
 
 #endif

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.h
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.h
@@ -38,7 +38,7 @@
     #define NO__GATHERING_CELL_DATA    0
     #define DONE__CELL_DATA_PROCESSED  1
     #define NO__WAITING_FOR_READY      2
-    #define DONE__READY_TO_TRIGGER     2
+    #define DONE__READY_TO_TRIGGER     3
 
     #define LTC6804_MAX_CONVERSION_TIME_ms 5 //4.43 ms in '2kHz' sampling mode
 

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.h
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.h
@@ -5,38 +5,40 @@
     #define LTC68042cell_h
 
     // trigger mode argument values to LTC68042cell_nextVoltages()
-    //  CONTINUOUS: trigger another acqusition as soon as possible
-    //    This mode piplines the acquisitions, so that the next acquisition can occur
+    //  ROUND_ROBIN: trigger another acquisition as soon as possible
+    //    This mode pipelines the acquisitions, so that the next acquisition can occur
     //    (in the BMS ic's) while the data from the current one is being processed.
-    //    60 cells require 21 calls (at apropriate intervels) to LTC68042cell_nextVoltages()
+    //    60 cells require 21 calls (at appropriate intervals) to LTC68042cell_nextVoltages()
     //    for a complete acquisition cycle.
-    //  TRIGGERED: trigger an acqusition only at the next call after CELL_DATA_PROCESSED
-    //    This mode allows a acquisition to be syncronized with events outside of
-    //    LTC68042cell_nextVoltages(), and is optimum for testing cell votage changes
+    //  TRIGGERED: trigger an acquisition only at the next call after DONE__CELL_DATA_PROCESSED
+    //    This mode allows an acquisition to be synchronized with events outside of
+    //    LTC68042cell_nextVoltages(), and is optimum for testing cell voltage changes
     //    in response to specific events. This adds 1 extra call for a complete cycle.
-    //  FORCE_TRIGGERED: trigger an acqusition NOW, abandoning any previous acqusition
-    //    that is in process. This is optimum as the first, single, call when when
-    //    switching from CONTINUOUS to TRIGGERED to get a new acquisition without having
-    //    to take the time to complete a full call cycle on the current acquisition.
-    // NOTE: It is only appripriate to make a call with LTC_TRIGGERMODE_FORCE_TRIGGERED one
-    //       time, to start a new acquisition cycle. Following calls should be with
-    //       LTC_TRIGGERMODE_TRIGGERED until LTC68042cell_nextVoltages() returns CELL_DATA_PROCESSED.
+    //  FORCE_TRIGGERED: transition to "ready to trigger" ASAP, abandoning any previous acqusition
+    //    that is in process. This is optimum when switching from ROUND_ROBIN to TRIGGERED to get
+    //    ready for a new acquisition without having to take the time to complete a full call cycle
+    //    on the current acquisition.
+    // NOTE: If an acquisition is in process when LTC_TRIGGERMODE_FORCE_TRIGGERED is used, it will
+    //       return NO__WAITING_FOR_READY, so keep calling until it returns DONE__READY_TO_TRIGGER,
+    //       indicating all is ready to start a new acquisition cycle. Following calls should be with
+    //       LTC_TRIGGERMODE_TRIGGERED until LTC68042cell_nextVoltages() returns DONE__CELL_DATA_PROCESSED.
     // Switching between modes at any time is supported.  LTC68042cell_nextVoltages() will do the
     //    best it can.
-    #define LTC_TRIGGERMODE_CONTINUOUS      0
+    #define LTC_TRIGGERMODE_ROUND_ROBIN     0
     #define LTC_TRIGGERMODE_TRIGGERED       1
     #define LTC_TRIGGERMODE_FORCE_TRIGGERED 2
 
-    #define LTC_STATE_FIRSTRUN 0
-    #define LTC_STATE_GATHER   1
-    #define LTC_STATE_PROCESS  2
-    #define LTC_STATE_GATHER_TRIGGERED   4 // not used
-    #define LTC_STATE_PROCESS_TRIGGERED  8
-    #define LTC_STATE_TRIGGER  16
+    #define LTC_STATE_FIRSTRUN           0
+    #define LTC_WAITING_FOR_ADC          1
+    #define LTC_STATE_GATHER             2
+    #define LTC_STATE_PROCESS            3
+    #define LTC_STATE_PROCESS_TRIGGERED  4
+    #define LTC_STATE_TRIGGER            5
 
-    #define GATHERING_CELL_DATA  0
-    #define CELL_DATA_PROCESSED  1
-    #define WAITING_TO_TRIGGER   2
+    #define NO__GATHERING_CELL_DATA    0
+    #define DONE__CELL_DATA_PROCESSED  1
+    #define NO__WAITING_FOR_READY      2
+    #define DONE__READY_TO_TRIGGER     2
 
     #define LTC6804_MAX_CONVERSION_TIME_ms 5 //4.43 ms in '2kHz' sampling mode
 

--- a/Firmware/firmwareLiBCM/src/LTC68042cell.h
+++ b/Firmware/firmwareLiBCM/src/LTC68042cell.h
@@ -3,17 +3,44 @@
 
 #ifndef LTC68042cell_h
     #define LTC68042cell_h
-    
+
+    // trigger mode argument values to LTC68042cell_nextVoltages()
+    //  CONTINUOUS: trigger another acqusition as soon as possible
+    //    This mode piplines the acquisitions, so that the next acquisition can occur
+    //    (in the BMS ic's) while the data from the current one is being processed.
+    //    60 cells require 21 calls (at apropriate intervels) to LTC68042cell_nextVoltages()
+    //    for a complete acquisition cycle.
+    //  TRIGGERED: trigger an acqusition only at the next call after CELL_DATA_PROCESSED
+    //    This mode allows a acquisition to be syncronized with events outside of
+    //    LTC68042cell_nextVoltages(), and is optimum for testing cell votage changes
+    //    in response to specific events. This adds 1 extra call for a complete cycle.
+    //  FORCE_TRIGGERED: trigger an acqusition NOW, abandoning any previous acqusition
+    //    that is in process. This is optimum as the first, single, call when when
+    //    switching from CONTINUOUS to TRIGGERED to get a new acquisition without having
+    //    to take the time to complete a full call cycle on the current acquisition.
+    // NOTE: It is only appripriate to make a call with LTC_TRIGGERMODE_FORCE_TRIGGERED one
+    //       time, to start a new acquisition cycle. Following calls should be with
+    //       LTC_TRIGGERMODE_TRIGGERED until LTC68042cell_nextVoltages() returns CELL_DATA_PROCESSED.
+    // Switching between modes at any time is supported.  LTC68042cell_nextVoltages() will do the
+    //    best it can.
+    #define LTC_TRIGGERMODE_CONTINUOUS      0
+    #define LTC_TRIGGERMODE_TRIGGERED       1
+    #define LTC_TRIGGERMODE_FORCE_TRIGGERED 2
+
     #define LTC_STATE_FIRSTRUN 0
     #define LTC_STATE_GATHER   1
     #define LTC_STATE_PROCESS  2
+    #define LTC_STATE_GATHER_TRIGGERED   4 // not used
+    #define LTC_STATE_PROCESS_TRIGGERED  8
+    #define LTC_STATE_TRIGGER  16
 
-    #define GATHERING_CELL_DATA 0
-    #define CELL_DATA_PROCESSED 1
+    #define GATHERING_CELL_DATA  0
+    #define CELL_DATA_PROCESSED  1
+    #define WAITING_TO_TRIGGER   2
 
     #define LTC6804_MAX_CONVERSION_TIME_ms 5 //4.43 ms in '2kHz' sampling mode
 
-    bool LTC68042cell_nextVoltages(void);
+    uint8_t LTC68042cell_nextVoltages(uint8_t triggerMode);
     void LTC68042cell_acquireAllCellVoltages(void);
 
 #endif

--- a/Firmware/firmwareLiBCM/src/LTC68042configure.cpp
+++ b/Firmware/firmwareLiBCM/src/LTC68042configure.cpp
@@ -17,7 +17,7 @@ uint8_t configurationRegisterData[6]; //[CFGR0, CFGR1, CFGR2, CFGR3, CFGR4, CFGR
 /////////////////////////////////////////////////////////////////////////////////////////
 
 //Write LTC6804 configuration registers
-//if (icAddress == BROADCAST_TO_ALL_ICS), this function broadcasts the same data to all LTC6804 ICs 
+//if (icAddress == BROADCAST_TO_ALL_ICS), this function broadcasts the same data to all LTC6804 ICs
 //
 // | config[0] | config[1] | config[2] | config[3] | config[4] | config[5] |
 // |-----------|-----------|-----------|-----------|-----------|-----------|
@@ -34,7 +34,7 @@ void LTC68042configure_writeConfigRegisters(uint8_t icAddress)
     else                                   { cmd[0] = 0x80 + (icAddress << 3); } //see datasheet Tables 33 & 34
 
     cmd[1] = 0x01; //send "write configuration registers" command ('WRCFG')
-  
+
     uint16_t temp_pec = LTC68042configure_calcPEC15(2, cmd); //calculate PEC
 
     cmd[2] = (uint8_t)(temp_pec >> 8); //upper PEC byte
@@ -74,7 +74,7 @@ void LTC68042configure_setBalanceResistors(uint8_t icAddress, uint16_t cellBitma
 //CFGR0:3 are reset when LTC watchdog timer expires (~2000 milliseconds)
 //CFGR4:5 are reset when LTC watchdog timer expires, unless software timer is set (and hasn't expired)
 void LTC68042configure_programVolatileDefaults(void)
-{                                                // BIT7    BIT6    BIT5    BIT4    BIT3    BIT2    BIT1   BIT0                
+{                                                // BIT7    BIT6    BIT5    BIT4    BIT3    BIT2    BIT1   BIT0
                                                  ///////////////////////////////////////////////////////////////
     configurationRegisterData[0] = 0b11111111 ;  //GPIO5   GPIO4   GPIO3   GPIO2   GPIO1   REFON   SWTRD  ADCOPT
     configurationRegisterData[1] = 0x00       ;  //VUV[7]  VUV[6]  VUV[5]  VUV[4]  VUV[3]  VUV[2]  VUV[1] VUV[0]
@@ -95,6 +95,29 @@ void LTC68042configure_programVolatileDefaults(void)
         //Note: fast, normal, or slow is configured in ADCV command
 
     LTC68042configure_writeConfigRegisters(BROADCAST_TO_ALL_ICS);
+    LTC68042cell_dischargeAllowedDuringConversion_set(IS_DISCHARGE_ALLOWED_DURING_CONVERSION);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+// Fatal Error terminal routine
+// Display the specified error message on the LCD display, beep, and turn off LiBCM
+void LTC68042configure_anounceFatalErrorAndDie(uint8_t warningToDisplay)
+{
+    lcdTransmit_begin();
+    delay(50); //delay doesn't matter because this is a fatal error
+    lcdTransmit_displayOn();
+    delay(50); //delay doesn't matter because this is a fatal error
+    lcdTransmit_Warning(warningToDisplay);
+
+    gpio_turnBuzzer_on_highFreq(); //call GPIO directly
+
+    wdt_disable(); //turn off watchdog to prevent reset
+    wdt_enable(WDTO_8S);
+
+    delay(7000); //give the user enough time to read error message
+
+    gpio_turnLiBCM_off(); //game over... thanks for playing
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -114,7 +137,7 @@ bool LTC68042configure_doesActualPackSizeMatchUserConfig(void)
             uint8_t errorCount_LTC6804_underTest[TOTAL_IC_60S] = {0}; //allocate for 60S even when user selects 48S
 
             //read data back from either QTY4 ICs (if user selects PACK_IS_48S in config.h), or QTY5 ICs (if user selects PACK_IS_60S in config.h)
-            //we don't care about the actual returned data; only that the PEC error count doesn't increment 
+            //we don't care about the actual returned data; only that the PEC error count doesn't increment
             for (uint8_t dut = 0; dut < TOTAL_IC; dut++)
             {
                 errorCount_LTC6804_underTest[dut] = LTC6804_rdaux(1,1,FIRST_IC_ADDR + dut); //read register 'A' on specified LTC6804
@@ -135,7 +158,7 @@ bool LTC68042configure_doesActualPackSizeMatchUserConfig(void)
                 //alert user and then turn off
 
                 Serial.print(F("\nError: measured cell count disagrees with user specified cell count in config.h."
-                               "\nLiBCM is disabled due to cell voltage monitoring IC issue. Debug:"));            
+                               "\nLiBCM is disabled due to cell voltage monitoring IC issue. Debug:"));
 
                 //cells 1:48 are the same for both 48S & 60S
                 for (uint8_t dut = 0; dut < TOTAL_IC; dut++)
@@ -153,21 +176,7 @@ bool LTC68042configure_doesActualPackSizeMatchUserConfig(void)
                     if (errorCount_LTC6804_underTest[4] == 0) { Serial.print(F("FAIL")); } //IC4 powered by cells 49:60
                     else                                      { Serial.print(F("pass")); }
                 }
-
-                lcdTransmit_begin();
-                delay(50); //delay doesn't matter because this is a fatal error
-                lcdTransmit_displayOn();
-                delay(50); //delay doesn't matter because this is a fatal error
-                lcdTransmit_Warning(LCD_WARN_CELL_COUNT);
-
-                gpio_turnBuzzer_on_highFreq(); //call GPIO directly
-                
-                wdt_disable(); //turn off watchdog to prevent reset
-                wdt_enable(WDTO_8S);
-
-                delay(7000); //give the user enough time to read error message
-
-                gpio_turnLiBCM_off(); //game over... thanks for playing
+                LTC68042configure_anounceFatalErrorAndDie(LCD_WARN_CELL_COUNT); //game over... thanks for playing
             }
         }
     #endif
@@ -187,7 +196,7 @@ void LTC68042configure_initialize(void)
 void LTC68042configure_pulseChipSelectLow(uint16_t lowPulsePeriod_us)
 {
     digitalWrite(PIN_SPI_CS,LOW); //low edge wakes up LTC
-    delayMicroseconds(lowPulsePeriod_us); //wait specified time for LTC to wake  
+    delayMicroseconds(lowPulsePeriod_us); //wait specified time for LTC to wake
     digitalWrite(PIN_SPI_CS,HIGH);
     lastTimeDataSent_millis = millis();
 }
@@ -197,12 +206,12 @@ void LTC68042configure_pulseChipSelectLow(uint16_t lowPulsePeriod_us)
 //wake up LTC core if watchdog timed out
 bool LTC68042configure_wakeupCore(void)
 {
-    const uint16_t T_SLEEP_WATCHDOG_MILLIS = 1800; //'tsleep' = 1800 (min) to 2200 (max) ms 
+    const uint16_t T_SLEEP_WATCHDOG_MILLIS = 1800; //'tsleep' = 1800 (min) to 2200 (max) ms
 
     bool wasCoreAlreadyAwake = LTC6804_CORE_ALREADY_AWAKE;
 
     if ((uint32_t)(millis() - lastTimeDataSent_millis) > T_SLEEP_WATCHDOG_MILLIS)
-    { 
+    {
         //LTC6804 core (probably) asleep
         LTC68042configure_pulseChipSelectLow(SPECIFIED_MAX_WAKEUP_TIME_LTCCORE_MICROSECONDS);
         wasCoreAlreadyAwake = LTC6804_CORE_JUST_WOKE_UP;
@@ -219,7 +228,7 @@ void LTC68042configure_wakeupIsoSPI(void)
     const uint8_t T_IDLE_isoSPI_MILLIS = 4; //'tIDLE' = 4.3 (min) to 6.7 (max) ms
 
     if ((uint32_t)(millis() - lastTimeDataSent_millis) > T_IDLE_isoSPI_MILLIS)
-    { 
+    {
         //LTC6804 isoSPI might be asleep (tIDLE elapsed)
          LTC68042configure_pulseChipSelectLow(SPECIFIED_MAX_WAKEUP_TIME_isoSPI_MICROSECONDS);
     }
@@ -232,8 +241,276 @@ bool LTC68042configure_wakeup(void)
     bool wasCoreAlreadyAwake = LTC68042configure_wakeupCore();
 
     if (wasCoreAlreadyAwake == LTC6804_CORE_ALREADY_AWAKE) { LTC68042configure_wakeupIsoSPI(); }
-  
+
     return wasCoreAlreadyAwake;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+static uint16_t cellVoltagesTest_counts[TOTAL_IC][CELLS_PER_IC];
+static uint32_t latestStateTimestamp_ms = 0;
+static uint16_t test1_cellStatusBitmap[TOTAL_IC] = {0};
+static uint16_t test2_cellStatusBitmap[TOTAL_IC] = {0};
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+///////// test helper functions
+void testHelper_clearCellTestFlags(int16_t testFlagBitmap[])
+{
+    for (uint8_t ic = 0; ic < TOTAL_IC; ic++)
+    {
+        testFlagBitmap[ic] = 0;
+    }
+}
+
+//helper function to set up a cell discharge circuit test
+void testHelper_saveCellVoltages(void)
+{
+    //save the prior cell voltage results away for later reference
+    for (uint8_t ic = 0; ic < TOTAL_IC; ic++)
+    {
+        for (uint8_t cellNumber = 0; cellNumber < CELLS_PER_IC; cellNumber++)
+        {
+            cellVoltagesTest_counts[ic][cellNumber] = LTC68042result_specificCellVoltage_get(ic, cellNumber);
+        }
+    }
+}
+
+//helper function to set up a cell discharge circuit test
+void testHelper_setCellDischarge(uint16_t cellDischargeBitmap)
+{
+    //turn on all odd or even cell balance circuits only
+    for (uint8_t ic = 0; ic < TOTAL_IC; ic++)
+    {
+        LTC68042configure_setBalanceResistors(
+           FIRST_IC_ADDR + ic,
+           cellDischargeBitmap,
+           LTC6804_DISCHARGE_TIMEOUT_02_SECONDS);
+        debugUSB_setCellBalanceStatus(ic, cellDischargeBitmap, 0); //WGCToDo: change arg 3 (cellDischargeVoltageThreshold) to something useful?
+    }
+}
+
+//helper function that looks for:
+//  adjacent cell voltage absulut deltas greater than a minimum (indicating discharge circuit works)
+//  cell voltages not insanely high or low (indicating no open sense wires)
+// returns true if all tests pass
+bool testHelper_checkInterCellDeltaAndSaneCellVoltages(
+   uint16_t cellFailsDeltaBitmap[], //cell bitmap for cells that are failing to discharge
+   uint16_t cellFailsHighBitmap[],  //cell bitmap for cells with excessively high voltage
+   uint16_t cellFailsLowBitmap[])   //cell bitmap for cells with excessively low voltage
+{
+    bool didTestPass = true;
+
+    for (uint8_t ic = 0; ic < TOTAL_IC; ic++)
+    {
+        for (uint8_t cellNumber = 0 ; cellNumber < CELLS_PER_IC; cellNumber++)
+        {
+            if (TESTBASIC_SANE_HIGH_TESTLIMIT_counts < cellVoltagesTest_counts[ic][cellNumber])
+            {
+                //then this cell fails high
+                cellFailsHighBitmap[ic] |= (1 << cellNumber);
+            }
+            else if (TESTBASIC_SANE_LOW_TESTLIMIT_counts > cellVoltagesTest_counts[ic][cellNumber])
+            {
+                //then this cell fails low
+                cellFailsLowBitmap[ic] |= (1 << cellNumber);
+            }
+            else if((CELLS_PER_IC - 1) > cellNumber) //WGCToDo: could also account for end cells on adjacent IC's
+            {
+                //check voltage delta between this cell and the next higher
+                int16_t cellDelta =   LTC68042result_specificCellVoltage_get(ic, cellNumber)      //voltage while discharging
+                                    - LTC68042result_specificCellVoltage_get(ic, cellNumber + 1); //voltage while discharging
+
+                //account for any initial cell imbalance
+                cellDelta -=   cellVoltagesTest_counts[ic][cellNumber]                //resting voltage
+                             - cellVoltagesTest_counts[ic][cellNumber + 1];           //resting voltage
+
+                if (0 > cellDelta) { cellDelta = - cellDelta; } //absolute value of cellDelta
+                if (TESTBASIC_DELTA_TESTLIMIT_counts > cellDelta)
+                {
+                    //cell fails, not enough IR drop delta, => current (I) too low (assuming R is not too low...)
+                    cellFailsDeltaBitmap[ic] |= (1 << cellNumber);
+                }
+            }
+        }
+        if (cellFailsHighBitmap[ic] || cellFailsLowBitmap[ic] || cellFailsDeltaBitmap[ic]) { didTestPass = false; }
+    }
+
+    return didTestPass;
+}
+
+void testHelper_printCellVoltages(const __FlashStringHelper * title)
+{
+    //WGCToDo: maybe add my own dedicated debug mode instead of DEBUGUSB_STREAM_DEBUG ('$DISP=DBG' -> 'DB2')
+    if (debugUSB_dataTypeToStream_get() == DEBUGUSB_STREAM_DEBUG)
+    {
+        Serial.println(F("")); //newline
+        Serial.print(title);
+        for (uint8_t ic = 0; ic < TOTAL_IC; ic++) debugUSB_printOneICsCellVoltages( ic, FOUR_DECIMAL_PLACES);
+        Serial.println("");
+    }
+}
+
+void testHelper_printTestResults(uint16_t cellFailuresBitmap[])
+{
+    bool allICsPassed = true;
+    for (uint8_t ic = 0; ic < TOTAL_IC; ic++) {if (cellFailuresBitmap[ic]) allICsPassed = false; }
+
+    if (allICsPassed)
+    {
+        Serial.print(F(" Passed"));
+    }
+    else
+    {
+        Serial.print(F(" FAILED!  Failed cell bitmaps: (0x) "));
+        for (uint8_t ic = 0; ic < (TOTAL_IC - 1); ic++)
+        {
+            Serial.print(cellFailuresBitmap[ic], HEX);
+            Serial.print(F(", "));
+        }
+        Serial.print(cellFailuresBitmap[TOTAL_IC - 1], HEX);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+//Run quick basic confidence test on BMS circuits
+bool LTC68042configure_basicConfidenceTest(void)
+{
+    bool didTestPass = true;
+
+    //note test start time
+    latestStateTimestamp_ms = millis();
+
+    //set up test
+    testHelper_clearCellTestFlags(test1_cellStatusBitmap); // re-use some available statics
+    testHelper_clearCellTestFlags(test2_cellStatusBitmap); // re-use some available statics
+    uint16_t test3_EvenTestCellFailsHighBitmap[TOTAL_IC] = {0};
+    uint16_t test4_EvenTestCellFailsLowBitmap[TOTAL_IC] = {0};
+    uint16_t test5_OddTestCellFailsHighBitmap[TOTAL_IC] = {0};
+    uint16_t test6_OddTestCellFailsLowBitmap[TOTAL_IC] = {0};
+    LTC68042cell_dischargeAllowedDuringConversion_set(DCP_ENABLED);
+
+    //verify LTC68042result_errorCount_get() doesn't increase during test
+    uint8_t errorCounts = LTC68042result_errorCount_get();
+
+    //tell the world that cells are balancing
+    cellBalance_set_cellsAreBalancing(YES);
+
+    //================== start with resting cell voltages
+    LTC68042cell_acquireAllCellVoltages(); //abandon any in-process acquisition (waiting for it to complete, if needed)
+    testHelper_saveCellVoltages();
+    testHelper_printCellVoltages(F("Resting:")); // controlled by '$DISP=DBG'
+
+    //================== now do even cells
+    testHelper_setCellDischarge(TESTBASIC_EvenCellsBitMap);
+
+    //measure and check while even cells are discharging
+    LTC68042cell_acquireAllCellVoltages();
+    testHelper_printCellVoltages(F("Even:")); // controlled by '$DISP=DBG'
+    didTestPass &= testHelper_checkInterCellDeltaAndSaneCellVoltages(
+      test1_cellStatusBitmap,            //cells not discharging
+      test3_EvenTestCellFailsHighBitmap, //cell voltages that way high => open sense wire
+      test4_EvenTestCellFailsLowBitmap); //cell voltages that way low  => open sense wire
+
+    //================== now do odd cells
+    //  (Yes, some redundncy in detecting open sense wires)
+    testHelper_setCellDischarge(TESTBASIC_OddCellsBitMap);
+
+    //measure and check while odd cells are discharging
+    LTC68042cell_acquireAllCellVoltages();
+    testHelper_printCellVoltages(F("Odd:")); // controlled by '$DISP=DBG'
+    didTestPass &= testHelper_checkInterCellDeltaAndSaneCellVoltages(
+      test2_cellStatusBitmap,            //cells not discharging
+      test5_OddTestCellFailsHighBitmap,  //cell voltages that way high => open sense wire
+      test6_OddTestCellFailsLowBitmap);  //cell voltages that way low  => open sense wire
+
+    //turn off all cell discharge circuits
+    disableDischargeResistors();
+
+    //tell the world that cells are no longer balancing
+    cellBalance_set_cellsAreBalancing(NO);
+
+    //test is done
+    uint32_t now_ms = millis();
+    errorCounts -= LTC68042result_errorCount_get();
+    LTC68042cell_dischargeAllowedDuringConversion_set(IS_DISCHARGE_ALLOWED_DURING_CONVERSION);
+
+    if (! didTestPass)
+    {
+        Serial.print(F("\nBasic BMS circuit test"));
+        Serial.print(F("\n   Acquisition errors: "));
+        if (0 == errorCounts) { Serial.print(F("None. Test should be good")); }
+        else
+        {
+            Serial.print(F("ERRORS OCCURRED. Test results may not be accurate, but there are other issues"));
+        }
+        Serial.print(F("\n   Discharge Circuit EVEN cell test: "));
+        testHelper_printTestResults(test1_cellStatusBitmap);
+        Serial.print(F("\n   Discharge Circuit ODD  cell test: "));
+        testHelper_printTestResults(test2_cellStatusBitmap);
+        Serial.print(F("\n   HIGH Cells EVEN cell test: "));
+        testHelper_printTestResults(test3_EvenTestCellFailsHighBitmap);
+        Serial.print(F("\n   LOW  Cells EVEN cell test: "));
+        testHelper_printTestResults(test4_EvenTestCellFailsLowBitmap);
+        Serial.print(F("\n   HIGH Cells ODD  cell test: "));
+        testHelper_printTestResults(test5_OddTestCellFailsHighBitmap);
+        Serial.print(F("\n   LOW  Cells ODD  cell test: "));
+        testHelper_printTestResults(test6_OddTestCellFailsLowBitmap);
+        Serial.println("");
+
+        uint16_t dischargeCellFlags = 0;
+        uint16_t openWireCellFlags = 0;
+        for (uint8_t ic = 0; ic < TOTAL_IC; ic++)
+        {
+            dischargeCellFlags =    test1_cellStatusBitmap[ic]
+                                  | test2_cellStatusBitmap[ic];
+            if (dischargeCellFlags)
+            {
+                Serial.print(F(" IC "));
+                Serial.print(ic);
+                Serial.print(F(" cells "));
+                for (uint8_t cellNumber = 0 ; cellNumber < CELLS_PER_IC; cellNumber++)
+                {
+                    if (dischargeCellFlags & (1 << cellNumber)) {
+                         Serial.print(cellNumber);
+                         Serial.print(F(", "));
+                    }
+                }
+                Serial.println(F("\n   likely have faulty LiBCM Cell Balance circuits"));
+            }
+
+            openWireCellFlags =    test3_EvenTestCellFailsHighBitmap[ic]
+                                 | test4_EvenTestCellFailsLowBitmap[ic]
+                                 | test5_OddTestCellFailsHighBitmap[ic]
+                                 | test6_OddTestCellFailsLowBitmap[ic];
+            if (openWireCellFlags)
+            {
+                Serial.print(F(" IC "));
+                Serial.print(ic);
+                Serial.print(F(" cells "));
+                for (uint8_t cellNumber = 0 ; cellNumber < CELLS_PER_IC; cellNumber++)
+                {
+                    if (openWireCellFlags & (1 << cellNumber)) {
+                         Serial.print(cellNumber);
+                         Serial.print(F(", "));
+                    }
+                }
+                Serial.println(F("\n   likely have open sense cable wire connections"));
+            }
+        }
+        Serial.print(F("\nBasic BMS test FAILED!   (elapsed test time (ms): "));
+        Serial.print(now_ms - latestStateTimestamp_ms);
+        Serial.println(")");
+        LTC68042configure_anounceFatalErrorAndDie(LCD_WARN_BASIC_TEST); //game over... thanks for testing
+    }
+    else
+    {
+        Serial.print(F("\nBasic BMS test passed (elapsed test time (ms): "));
+        Serial.print(now_ms - latestStateTimestamp_ms);
+        Serial.println(")");
+    }
+    return didTestPass;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -249,7 +526,7 @@ uint16_t LTC68042configure_calcPEC15(uint8_t len, //data array length
         addr = ( (remainder>>7)^data[i] ) & 0xff;//calculate PEC table address
         remainder = (remainder<<8) ^ crc15Table[addr];
     }
-  
+
     return(remainder<<1);//The CRC15 LSB is 0, so multiply by 2
 }
 

--- a/Firmware/firmwareLiBCM/src/LTC68042configure.h
+++ b/Firmware/firmwareLiBCM/src/LTC68042configure.h
@@ -47,9 +47,9 @@
     #define AUX_CH_GPIO5 5
     #define AUX_CH_VREF2 6
 
-    //JTS2doLater: Does reducing corner frequency to 26 Hz reduce assist/regen noise? //Add 214 ms wait before reading 
+    //JTS2doLater: Does reducing corner frequency to 26 Hz reduce assist/regen noise? //Add 214 ms wait before reading
     //ADC LPF Fcorner:       Total conversion time (QTY12 cells/IC)
-    //ADCOPT(CFGR0[0] = 0)    
+    //ADCOPT(CFGR0[0] = 0)
     // MD = 01 27000 Hz        1.2 ms fast
     // MD = 10  7000 Hz        2.5 ms (default)
     // MD = 11    26 Hz      213.5 ms filtered
@@ -66,7 +66,7 @@
     #define MD_NORMAL 2
     #define MD_FILTERED 3
 
-    
+
     // |CH | Dec  | Channels to convert |
     // |---|------|---------------------|
     // |000| 0    | All Cells           |
@@ -179,24 +179,41 @@
 
     #define LTC6804_MASK_REFON_BIT 0x02
 
+    //======================= Basic cell discharge circuit test
+    #define TESTBASIC_EvenCellsBitMap 0b0000010101010101
+    #define TESTBASIC_OddCellsBitMap  0b0000101010101010
+    // This quick test first aims to detect open BMS sense wires by
+    //   verifying that cell voltages measure within sane limits while
+    //   the cell balance circuits are active.
+    // Sane cell voltage high limit (while cell balance circuit is active):
+    //   a measured cell voltage above this value is "not sane", and
+    //   probably indicates an open BMS sense wire
+    #define TESTBASIC_SANE_HIGH_TESTLIMIT_counts   CELL_VMAX_REGEN
+    // Sane cell voltage low limit (while cell balance circuit is active):
+    //   a measured cell voltage below this value is "not sane", and
+    //   probably (also) indicates an open BMS sense wire
+    #define TESTBASIC_SANE_LOW_TESTLIMIT_counts    CELL_VMIN_GRIDCHARGER
+    // Next, the test attempts verify that the cell discharge circuits
+    //   actually draw current by measuring the IR drop in the BMS sense
+    //   wires and connections.
+    // Cells with a voltage delta below this limit either aren't drawing
+    //   current or are always drawing current. Either way there is a
+    //   BMS discharge circuit failure.
+    //   Another possibility is that they have anomalously low
+    //   cable/wire/connection resistance (deemed unlikely).
+    // cell voltage delta limit:
+    #define TESTBASIC_DELTA_TESTLIMIT_counts  30 //WGCToDoNext: this limit surely needs refinement, and likely won't work in BMS_TYPE_WGCLiBCM at all
+
+    //Exteral (public) functions (aka LTC68042 API)
     void LTC68042configure_initialize(void);
-
     void LTC68042configure_handleKeyStateChange(void);
-
     bool LTC68042configure_wakeup(void);
-
     uint16_t LTC68042configure_calcPEC15(uint8_t len, uint8_t const data[]);
-
-    void LTC68042configure_spiWrite( uint8_t length, uint8_t const data[]);
-
+    void LTC68042configure_spiWrite(uint8_t length, uint8_t const data[]);
     void LTC68042configure_spiWriteRead(uint8_t *TxData, uint8_t TXlen, uint8_t *rx_data, uint8_t RXlen);
-
     void LTC68042configure_programVolatileDefaults(void);
-    
     void LTC68042configure_setBalanceResistors(uint8_t icAddress, uint16_t cellBitmap, uint8_t softwareTimeout);
-
     bool LTC68042configure_doesActualPackSizeMatchUserConfig(void);
-
     void LTC68042configure_pulseChipSelectLow(uint16_t lowPulsePeriod_us);
-
+    bool LTC68042configure_basicConfidenceTest(void);
 #endif

--- a/Firmware/firmwareLiBCM/src/cellBalance.cpp
+++ b/Firmware/firmwareLiBCM/src/cellBalance.cpp
@@ -21,7 +21,7 @@ bool cellsAreBalancing = NO;
 // if (hasOneSecondPassed && (balancingComplete == FALSE)) {
 //    for (cellNumber=1; cellNumber<NUMCELLS; cellNumber++) {
 //       if (cellStatus[cellNumber] == BALANCING) { cellBalanceTimer_seconds[cellNumber]++; }
-// }} 
+// }}
 
 //Allow LiBCM to print this array over USB
 // -if all cells are similar, then all array elements should have similar values (ideally they would all be 0).
@@ -36,6 +36,7 @@ bool cellsAreBalancing = NO;
 /////////////////////////////////////////////////////////////////////////////////////////
 
 bool cellBalance_areCellsBalancing(void) { return cellsAreBalancing; }
+void cellBalance_set_cellsAreBalancing(bool cellsBalancing) { cellsAreBalancing = cellsBalancing; }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Firmware/firmwareLiBCM/src/cellBalance.h
+++ b/Firmware/firmwareLiBCM/src/cellBalance.h
@@ -7,9 +7,11 @@
     #define BALANCING_DISABLED 0
     #define BALANCING_ALLOWED  1
 
-	#define YES__BALANCING_ALLOWED YES__CHARGING_ALLOWED //balancing code reusing grid charging constants
+    #define YES__BALANCING_ALLOWED YES__CHARGING_ALLOWED //balancing code reusing grid charging constants
 
     bool cellBalance_areCellsBalancing(void);
+    void cellBalance_set_cellsAreBalancing(bool cellsBalancing);
+    void disableDischargeResistors(void);
 
     void cellBalance_handler(void);
 

--- a/Firmware/firmwareLiBCM/src/key.cpp
+++ b/Firmware/firmwareLiBCM/src/key.cpp
@@ -30,6 +30,7 @@ void key_handleKeyEvent_off(void)
     eeprom_keyOffCheckForExpiredFirmware();
     LTC68042configure_doesActualPackSizeMatchUserConfig();
 
+    LTC68042configure_basicConfidenceTest();
     time_latestKeyOff_ms_set(millis()); //MUST RUN LAST!
 }
 

--- a/Firmware/firmwareLiBCM/src/key.cpp
+++ b/Firmware/firmwareLiBCM/src/key.cpp
@@ -111,7 +111,6 @@ void keyOn_coldBootTasks(void)
     gpio_turnPowerSensors_on();
     LTC68042configure_pulseChipSelectLow(SPECIFIED_MAX_WAKEUP_TIME_LTCCORE_MICROSECONDS); //wake LTC6804
     LTC68042cell_nextVoltages(); //first call starts LTC6804 conversion
-    uint32_t timeSinceLTC6804conversionStarted_us = millis();
 
     //other startup initialization tasks
     vPackSpoof_handleKeyON();

--- a/Firmware/firmwareLiBCM/src/key.cpp
+++ b/Firmware/firmwareLiBCM/src/key.cpp
@@ -119,9 +119,8 @@ void keyOn_coldBootTasks(void)
     METSCI_enable();
     LED(3,ON);
 
-    //process cell voltages
-    while(millis() - timeSinceLTC6804conversionStarted_us < LTC6804_MAX_CONVERSION_TIME_ms) { ; } //wait for conversion to finish
-    while(LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //read all cell voltages back
+    //read and process cell voltages, waiting for conversion to finish if needed
+    while(LTC68042cell_nextVoltages() != DONE__CELL_DATA_PROCESSED) { ; } //read all cell voltages back
     vPackSpoof_setVoltage();
     SoC_setBatteryStateNow_percent(SoC_estimateFromRestingCellVoltage_percent());
     BATTSCI_enable(); //must occur after we have valid Vcell data

--- a/Firmware/firmwareLiBCM/src/key.cpp
+++ b/Firmware/firmwareLiBCM/src/key.cpp
@@ -110,7 +110,7 @@ void keyOn_coldBootTasks(void)
     //initialize hardware
     gpio_turnPowerSensors_on();
     LTC68042configure_pulseChipSelectLow(SPECIFIED_MAX_WAKEUP_TIME_LTCCORE_MICROSECONDS); //wake LTC6804
-    LTC68042cell_nextVoltages(); //first call starts LTC6804 conversion
+    LTC68042cell_nextVoltages(LTC_TRIGGERMODE_CONTINUOUS); //first call starts LTC6804 conversion
     uint32_t timeSinceLTC6804conversionStarted_us = millis();
 
     //other startup initialization tasks
@@ -119,9 +119,8 @@ void keyOn_coldBootTasks(void)
     METSCI_enable();
     LED(3,ON);
 
-    //process cell voltages
-    while(millis() - timeSinceLTC6804conversionStarted_us < LTC6804_MAX_CONVERSION_TIME_ms) { ; } //wait for conversion to finish
-    while(LTC68042cell_nextVoltages() != CELL_DATA_PROCESSED) { ; } //read all cell voltages back
+    //read and process cell voltages, waiting for conversion to finish if needed
+    while(LTC68042cell_nextVoltages(LTC_TRIGGERMODE_CONTINUOUS) != CELL_DATA_PROCESSED) { ; } //read all cell voltages back
     vPackSpoof_setVoltage();
     SoC_setBatteryStateNow_percent(SoC_estimateFromRestingCellVoltage_percent());
     BATTSCI_enable(); //must occur after we have valid Vcell data

--- a/Firmware/firmwareLiBCM/src/key.cpp
+++ b/Firmware/firmwareLiBCM/src/key.cpp
@@ -110,7 +110,7 @@ void keyOn_coldBootTasks(void)
     //initialize hardware
     gpio_turnPowerSensors_on();
     LTC68042configure_pulseChipSelectLow(SPECIFIED_MAX_WAKEUP_TIME_LTCCORE_MICROSECONDS); //wake LTC6804
-    LTC68042cell_nextVoltages(LTC_TRIGGERMODE_CONTINUOUS); //first call starts LTC6804 conversion
+    LTC68042cell_nextVoltages(LTC_TRIGGERMODE_ROUND_ROBIN); //first call starts LTC6804 conversion
     uint32_t timeSinceLTC6804conversionStarted_us = millis();
 
     //other startup initialization tasks
@@ -120,7 +120,7 @@ void keyOn_coldBootTasks(void)
     LED(3,ON);
 
     //read and process cell voltages, waiting for conversion to finish if needed
-    while(LTC68042cell_nextVoltages(LTC_TRIGGERMODE_CONTINUOUS) != CELL_DATA_PROCESSED) { ; } //read all cell voltages back
+    while(LTC68042cell_nextVoltages(LTC_TRIGGERMODE_ROUND_ROBIN) != DONE__CELL_DATA_PROCESSED) { ; } //read all cell voltages back
     vPackSpoof_setVoltage();
     SoC_setBatteryStateNow_percent(SoC_estimateFromRestingCellVoltage_percent());
     BATTSCI_enable(); //must occur after we have valid Vcell data

--- a/Firmware/firmwareLiBCM/src/lcdTransmit.cpp
+++ b/Firmware/firmwareLiBCM/src/lcdTransmit.cpp
@@ -52,7 +52,7 @@ bool whichCycleFrameToDisplay(void)
     uint32_t timeKeyOn_ms = time_sinceLatestKeyOn_ms();
 
     uint16_t frameDisplayPeriod_ms = 0;
-    
+
     if      (cycleFrameNumber == CYCLEFRAME_A)  { frameDisplayPeriod_ms = CYCLEFRAME_A_PERIOD_ms; }
     else if (cycleFrameNumber == CYCLEFRAME_B)  { frameDisplayPeriod_ms = CYCLEFRAME_B_PERIOD_ms; }
 
@@ -90,7 +90,7 @@ bool lcd_flashBacklight(void)
         else                      { lcd2.backlight();   isBacklightOn = YES; }
 
         lastBacklightStateChange_ms = millis();
-        didscreenUpdateOccur = SCREEN_UPDATED;      
+        didscreenUpdateOccur = SCREEN_UPDATED;
     }
 
     return didscreenUpdateOccur;
@@ -169,7 +169,7 @@ bool lcd_printWattHours(void)
     uint16_t wattHours_new = 0;
     if      (cycleFrameNumber == CYCLEFRAME_A) { wattHours_new = wattHoursAssist; }
     else if (cycleFrameNumber == CYCLEFRAME_B) { wattHours_new = wattHoursRegen;  }
-        
+
 
     if (wattHours_new != wattHours_onScreen)
     {
@@ -202,9 +202,9 @@ bool lcd_printSoC(void)
     {
         lcd2.setCursor(7,3); //'ss.s' screen position
         if (SoC_deciPercent < 100) { lcd2.print('0'); } //add leading '0' when SoC is less than 10.0%
-        
+
         if (key_getSampledState() == KEYSTATE_ON) { lcd2.print(SoC_deciPercent * 0.1, 1);                      } //integrator
-        else                                      { lcd2.print(SoC_deciPercent * 0.1, 0); lcd2.print(F(".x")); } //uint SoC LUT 
+        else                                      { lcd2.print(SoC_deciPercent * 0.1, 0); lcd2.print(F(".x")); } //uint SoC LUT
 
         SoC_onScreen = SoC_deciPercent;
         didscreenUpdateOccur = SCREEN_UPDATED;
@@ -269,9 +269,9 @@ bool lcd_printTempBattery(void)
         lcd2.setCursor(12,0);
 
         if ((battTemp >= 0) && (battTemp < 10)) { lcd2.print(' '); } //leading space on " 0" to " 9" degC
-        
+
         lcd2.print(battTemp);
-        
+
         if ( battTemp >= -9 ) { lcd2.print('C'); } //'C' not printed below -9C (e.g. "-10")
 
         didscreenUpdateOccur = SCREEN_UPDATED;
@@ -430,27 +430,27 @@ bool lcd_printCurrent(void)
         int16_t abs_deciAmps = abs(deciAmps);
 
         lcd2.setCursor(6,2);
-  
+
         //add leading space when necessary
         if ((abs_deciAmps <   100) || //less than 10 amps (e.g. " +9.9")
-            (abs_deciAmps >= 1000)  ) //decimal not displayed above 100 amps (e.g. " +100") 
+            (abs_deciAmps >= 1000)  ) //decimal not displayed above 100 amps (e.g. " +100")
         {
             lcd2.print(' ');
         }
 
         #ifdef DISPLAY_NEGATIVE_SIGN_DURING_ASSIST
-            if      (deciAmps > 0) { lcd2.print('-'); } //When discharging battery (i.e. assist), we display '-' symbol, even though internally it's '+' 
-            else if (deciAmps < 0) { lcd2.print('+'); } //When    charging battery (i.e. regen ), we display '+' symbol, even though internally it's '-' 
+            if      (deciAmps > 0) { lcd2.print('-'); } //When discharging battery (i.e. assist), we display '-' symbol, even though internally it's '+'
+            else if (deciAmps < 0) { lcd2.print('+'); } //When    charging battery (i.e. regen ), we display '+' symbol, even though internally it's '-'
             else                   { lcd2.print(' '); }
         #elif defined DISPLAY_POSITIVE_SIGN_DURING_ASSIST
             if      (deciAmps > 0) { lcd2.print('+'); } //When discharging battery (i.e. assist), we display '+' symbol
-            else if (deciAmps < 0) { lcd2.print('-'); } //When    charging battery (i.e. regen ), we display '+' symbol 
+            else if (deciAmps < 0) { lcd2.print('-'); } //When    charging battery (i.e. regen ), we display '+' symbol
             else                   { lcd2.print(' '); }
         #endif
 
         if (abs_deciAmps < 1000) { lcd2.print(abs_deciAmps * 0.1, 1); }
         else                     { lcd2.print(abs_deciAmps * 0.1, 0); }
-        
+
         deciAmps_onScreen = deciAmps;
         didscreenUpdateOccur = SCREEN_UPDATED;
     }
@@ -513,12 +513,12 @@ bool lcd_printPower(void)
         if (abs_deci_kW <  100) { lcd2.print(' '); } //add one leading space (e.g. " +9.9")
 
         #ifdef DISPLAY_NEGATIVE_SIGN_DURING_ASSIST
-            if      (deci_kW > 0) { lcd2.print('-'); } //When discharging battery (i.e. assist), we display '-' symbol, even though internally it's '+' 
-            else if (deci_kW < 0) { lcd2.print('+'); } //When    charging battery (i.e. regen ), we display '+' symbol, even though internally it's '-' 
+            if      (deci_kW > 0) { lcd2.print('-'); } //When discharging battery (i.e. assist), we display '-' symbol, even though internally it's '+'
+            else if (deci_kW < 0) { lcd2.print('+'); } //When    charging battery (i.e. regen ), we display '+' symbol, even though internally it's '-'
             else                  { lcd2.print(' '); }
         #elif defined DISPLAY_POSITIVE_SIGN_DURING_ASSIST
             if      (deci_kW > 0) { lcd2.print('+'); } //When discharging battery (i.e. assist), we display '+' symbol
-            else if (deci_kW < 0) { lcd2.print('-'); } //When    charging battery (i.e. regen ), we display '-' symbol 
+            else if (deci_kW < 0) { lcd2.print('-'); } //When    charging battery (i.e. regen ), we display '-' symbol
             else                  { lcd2.print(' '); }
         #endif
 
@@ -665,7 +665,15 @@ void lcdTransmit_Warning(uint8_t warningToDisplay)
         lcd2.setCursor(0,1); lcd2.print(F("       count doesn't"));
         lcd2.setCursor(0,2); lcd2.print(F("       match setting"));
         lcd2.setCursor(0,3); lcd2.print(F("       in config.h  "));
-    }   
+    }
+
+    else if (warningToDisplay == LCD_WARN_BASIC_TEST)
+    {
+        lcd2.setCursor(0,0); lcd2.print(F("ALERT: Cell balance "));
+        lcd2.setCursor(0,1); lcd2.print(F("  circuit fauit     "));
+        lcd2.setCursor(0,2); lcd2.print(F("  Sense cable or    "));
+        lcd2.setCursor(0,3); lcd2.print(F("  LiBCM PCB         "));
+    }
 
     if (++whichRowToPrint > 3) { whichRowToPrint = 0; }
 
@@ -691,7 +699,7 @@ bool lcd_updateValue(uint8_t stateToUpdate)
     bool didScreenUpdateOccur = SCREEN_DIDNT_UPDATE;
     switch (stateToUpdate)
     {
-        case LCDVALUE_CALC_CYCLEFRAME: didScreenUpdateOccur = whichCycleFrameToDisplay();      break;             
+        case LCDVALUE_CALC_CYCLEFRAME: didScreenUpdateOccur = whichCycleFrameToDisplay();      break;
         case LCDVALUE_SECONDS        : didScreenUpdateOccur = lcd_printTime_unitless();        break;
         case LCDVALUE_VPACK_ACTUAL   : didScreenUpdateOccur = lcd_printStackVoltage_actual();  break;
         case LCDVALUE_VPACK_SPOOFED  : didScreenUpdateOccur = lcd_printStackVoltage_spoofed(); break;
@@ -746,7 +754,7 @@ void updateNextVariable(void)
 
     do
     {
-        if (isMinimumDisplayPeriodMet(lcdVariableToUpdate) == YES) 
+        if (isMinimumDisplayPeriodMet(lcdVariableToUpdate) == YES)
         {
             didScreenUpdateOccur = lcd_updateValue(lcdVariableToUpdate);
         }
@@ -784,7 +792,7 @@ void updateNextVariable(void)
     //      |****|****|****|****    cellMaxNow    cellMaxKey  battTemp  isoSPI  fan  charger  heater balance
     //Row0 "Hx.xxx<y.yy kkCEFGHB" | Hx.xxx        <y.yy       kkC       E       f|F  G        H      B
     //
-    //      |****|****|****|****    cellMinNow    cellMinKey  VpackActual  VpackSpoof         
+    //      |****|****|****|****    cellMinNow    cellMinKey  VpackActual  VpackSpoof
     //Row1 "La.aaa>j.jj rrr~mmmV" | La.aaa        >j.jj       rrr~         mmmV       //'~' prints as a right arrow
     //
     //      |****|****|****|****    cellDeltamV   packAmps    power_kW
@@ -821,7 +829,7 @@ bool updateNextStatic(void)
     }
 
     bool doneDisplayingStaticValues = NO;
-    
+
     if (++lcdStaticElementToUpdate > LCDSTATIC_MAX_VALUE)
     {
         doneDisplayingStaticValues = YES;

--- a/Firmware/firmwareLiBCM/src/lcdTransmit.h
+++ b/Firmware/firmwareLiBCM/src/lcdTransmit.h
@@ -8,7 +8,7 @@
     #define SCREEN_UPDATED      true
 
     //define screen elements
-    //up to one screen element is updated each loop, using round robbin state machine 
+    //up to one screen element is updated each loop, using round robbin state machine
     #define LCDVALUE_NO_UPDATE        0
     #define LCDVALUE_CALC_CYCLEFRAME  1
     #define LCDVALUE_SECONDS          2
@@ -79,6 +79,7 @@
     #define LCD_WARN_FW_EXPIRED 2
     #define LCD_WARN_COVER_GONE 3
     #define LCD_WARN_CELL_COUNT 4
+    #define LCD_WARN_BASIC_TEST 5
     void lcdTransmit_Warning(uint8_t warningToDisplay);
 
 #endif

--- a/Firmware/firmwareLiBCM/src/powerSave.cpp
+++ b/Firmware/firmwareLiBCM/src/powerSave.cpp
@@ -28,7 +28,7 @@ void powerSave_turnOffLiBCM_ifPackEmpty(void)
     else if ((LTC68042result_loCellVoltage_get() < CELL_VMIN_KEYOFF) && //battery is low
              (time_hasKeyBeenOffLongEnough_toTurnOffLiBCM() == true) && //give user time to plug in charger
              (gpio_isGridChargerChargingNow() == NO)                  ) //grid charger isn't charging
-    {   
+    {
         Serial.print(F("\nBattery is low"));
         gpio_turnLiBCM_off(); //game over, thanks for playing
     }
@@ -84,7 +84,7 @@ void wakeupInterrupts_timer2_enable(void)
 {
     power_timer2_enable();  //enable timer2 clock
     TCNT2 = 0; //set timer2 count to zero
-    TIFR2  |= (1 << TOV2 ); //clear pending interrupt flag, if set      
+    TIFR2  |= (1 << TOV2 ); //clear pending interrupt flag, if set
     TIMSK2 |= (1 << TOIE2); //enable timer2 overflow interrupt
 }
 
@@ -131,7 +131,7 @@ void powerSave_gotoSleep(void)
     interruptSource = USB_INTERRUPT; //see ISR(PCINT1_vect) for more info
 
     LED_turnAllOff(); //saves power
-    
+
     USB_delayUntilTransmitBufferEmpty();
     USB_end();
 
@@ -186,7 +186,8 @@ void powerSave_turnOffIfAllowed(void)
     #ifdef POWEROFF_DELAY_AFTER_KEYOFF_DAYS
         uint32_t timeSinceLatestKeyOff_ms = millis() - time_latestKeyOff_ms_get();
 
-        if ((gpio_isGridChargerPluggedInNow() == NO)                                                            &&
+        if ((cellBalance_areCellsBalancing()  == NO) /* LiBCM must stay on for safety */                        &&
+            (gpio_isGridChargerPluggedInNow() == NO) /* LiBCM must stay on for safety */                        &&
             (time_sinceLatestGridChargerUnplug_get_ms() > PERIOD_TO_DISABLE_TURNOFF_AFTER_CHARGER_UNPLUGGED_ms) &&
             (timeSinceLatestKeyOff_ms > (POWEROFF_DELAY_AFTER_KEYOFF_DAYS * MILLISECONDS_PER_DAY))               )
         {
@@ -226,14 +227,14 @@ ISR(PCINT0_vect)
 //this interrupt disabled when LiBCM is awake
 ISR(PCINT1_vect)
 {
-    //interruptSource = USB_INTERRUPT; //this code isn't guaranteed to run (see below) 
+    //interruptSource = USB_INTERRUPT; //this code isn't guaranteed to run (see below)
     //wakeupInterrupts_disable();      //this code isn't guaranteed to run (see below)
 
     //the hardware pin change interrupt that occurs when USB Rx pin toggles is guaranteed to wake the CPU from sleep.
     //HOWEVER, the code in PCINT1_vect ISR isn't guaranteed to run (and probably won't), as explained next.
     //This was super annoying to figure out, hence the labored explanation:
     //
-    //From the atmega2560 manual, Chapter 15 "External interrupts": 
+    //From the atmega2560 manual, Chapter 15 "External interrupts":
         //"Note that if a level triggered interrupt is used for wake-up from Power-down," ...
         //..."the required level must be held long enough for the MCU to complete the wake-up to trigger the level interrupt."
         //"If the level disappears before the end of the Start-up Time, the MCU will still wake up, but no interrupt will be generated."


### PR DESCRIPTION
(This feature is not quite ready for release, but review and testing is welcome...)
Add LTC68042configure_basicConfidenceTest() to key_handleKeyEvent_off() to use the cell balance circuits to check that the cell sense cable connections have continuity.  The test adds ~51 ms to the duration of key_handleKeyEvent_off().  This increases the latency for detecting a key-on event after a key-off event is detected.  The existing latency is ~30 ms, and now it is ~80 ms.  There is evidence that there is roughly 180 ms available (sample of one...).
This change also adds functions to LTC68042cell.cpp to support allowing cell balance circuits operation while cell voltage measurements are underway.